### PR TITLE
Bump kinobi versions, with renderers-js to 0.21.9

### DIFF
--- a/clients/js/src/generated/instructions/amountToUiAmount.ts
+++ b/clients/js/src/generated/instructions/amountToUiAmount.ts
@@ -28,6 +28,12 @@ import {
 import { TOKEN_PROGRAM_ADDRESS } from '../programs';
 import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
 
+export const AMOUNT_TO_UI_AMOUNT_DISCRIMINATOR = 23;
+
+export function getAmountToUiAmountDiscriminatorBytes() {
+  return getU8Encoder().encode(AMOUNT_TO_UI_AMOUNT_DISCRIMINATOR);
+}
+
 export type AmountToUiAmountInstruction<
   TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
   TAccountMint extends string | IAccountMeta<string> = string,
@@ -60,7 +66,7 @@ export function getAmountToUiAmountInstructionDataEncoder(): Encoder<AmountToUiA
       ['discriminator', getU8Encoder()],
       ['amount', getU64Encoder()],
     ]),
-    (value) => ({ ...value, discriminator: 23 })
+    (value) => ({ ...value, discriminator: AMOUNT_TO_UI_AMOUNT_DISCRIMINATOR })
   );
 }
 
@@ -87,11 +93,15 @@ export type AmountToUiAmountInput<TAccountMint extends string = string> = {
   amount: AmountToUiAmountInstructionDataArgs['amount'];
 };
 
-export function getAmountToUiAmountInstruction<TAccountMint extends string>(
-  input: AmountToUiAmountInput<TAccountMint>
-): AmountToUiAmountInstruction<typeof TOKEN_PROGRAM_ADDRESS, TAccountMint> {
+export function getAmountToUiAmountInstruction<
+  TAccountMint extends string,
+  TProgramAddress extends Address = typeof TOKEN_PROGRAM_ADDRESS,
+>(
+  input: AmountToUiAmountInput<TAccountMint>,
+  config?: { programAddress?: TProgramAddress }
+): AmountToUiAmountInstruction<TProgramAddress, TAccountMint> {
   // Program address.
-  const programAddress = TOKEN_PROGRAM_ADDRESS;
+  const programAddress = config?.programAddress ?? TOKEN_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -112,7 +122,7 @@ export function getAmountToUiAmountInstruction<TAccountMint extends string>(
     data: getAmountToUiAmountInstructionDataEncoder().encode(
       args as AmountToUiAmountInstructionDataArgs
     ),
-  } as AmountToUiAmountInstruction<typeof TOKEN_PROGRAM_ADDRESS, TAccountMint>;
+  } as AmountToUiAmountInstruction<TProgramAddress, TAccountMint>;
 
   return instruction;
 }

--- a/clients/js/src/generated/instructions/approve.ts
+++ b/clients/js/src/generated/instructions/approve.ts
@@ -33,6 +33,12 @@ import {
 import { TOKEN_PROGRAM_ADDRESS } from '../programs';
 import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
 
+export const APPROVE_DISCRIMINATOR = 4;
+
+export function getApproveDiscriminatorBytes() {
+  return getU8Encoder().encode(APPROVE_DISCRIMINATOR);
+}
+
 export type ApproveInstruction<
   TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
   TAccountSource extends string | IAccountMeta<string> = string,
@@ -73,7 +79,7 @@ export function getApproveInstructionDataEncoder(): Encoder<ApproveInstructionDa
       ['discriminator', getU8Encoder()],
       ['amount', getU64Encoder()],
     ]),
-    (value) => ({ ...value, discriminator: 4 })
+    (value) => ({ ...value, discriminator: APPROVE_DISCRIMINATOR })
   );
 }
 
@@ -113,10 +119,12 @@ export function getApproveInstruction<
   TAccountSource extends string,
   TAccountDelegate extends string,
   TAccountOwner extends string,
+  TProgramAddress extends Address = typeof TOKEN_PROGRAM_ADDRESS,
 >(
-  input: ApproveInput<TAccountSource, TAccountDelegate, TAccountOwner>
+  input: ApproveInput<TAccountSource, TAccountDelegate, TAccountOwner>,
+  config?: { programAddress?: TProgramAddress }
 ): ApproveInstruction<
-  typeof TOKEN_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountSource,
   TAccountDelegate,
   (typeof input)['owner'] extends TransactionSigner<TAccountOwner>
@@ -124,7 +132,7 @@ export function getApproveInstruction<
     : TAccountOwner
 > {
   // Program address.
-  const programAddress = TOKEN_PROGRAM_ADDRESS;
+  const programAddress = config?.programAddress ?? TOKEN_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -162,7 +170,7 @@ export function getApproveInstruction<
       args as ApproveInstructionDataArgs
     ),
   } as ApproveInstruction<
-    typeof TOKEN_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountSource,
     TAccountDelegate,
     (typeof input)['owner'] extends TransactionSigner<TAccountOwner>

--- a/clients/js/src/generated/instructions/approveChecked.ts
+++ b/clients/js/src/generated/instructions/approveChecked.ts
@@ -33,6 +33,12 @@ import {
 import { TOKEN_PROGRAM_ADDRESS } from '../programs';
 import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
 
+export const APPROVE_CHECKED_DISCRIMINATOR = 13;
+
+export function getApproveCheckedDiscriminatorBytes() {
+  return getU8Encoder().encode(APPROVE_CHECKED_DISCRIMINATOR);
+}
+
 export type ApproveCheckedInstruction<
   TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
   TAccountSource extends string | IAccountMeta<string> = string,
@@ -82,7 +88,7 @@ export function getApproveCheckedInstructionDataEncoder(): Encoder<ApproveChecke
       ['amount', getU64Encoder()],
       ['decimals', getU8Encoder()],
     ]),
-    (value) => ({ ...value, discriminator: 13 })
+    (value) => ({ ...value, discriminator: APPROVE_CHECKED_DISCRIMINATOR })
   );
 }
 
@@ -128,15 +134,17 @@ export function getApproveCheckedInstruction<
   TAccountMint extends string,
   TAccountDelegate extends string,
   TAccountOwner extends string,
+  TProgramAddress extends Address = typeof TOKEN_PROGRAM_ADDRESS,
 >(
   input: ApproveCheckedInput<
     TAccountSource,
     TAccountMint,
     TAccountDelegate,
     TAccountOwner
-  >
+  >,
+  config?: { programAddress?: TProgramAddress }
 ): ApproveCheckedInstruction<
-  typeof TOKEN_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountSource,
   TAccountMint,
   TAccountDelegate,
@@ -145,7 +153,7 @@ export function getApproveCheckedInstruction<
     : TAccountOwner
 > {
   // Program address.
-  const programAddress = TOKEN_PROGRAM_ADDRESS;
+  const programAddress = config?.programAddress ?? TOKEN_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -185,7 +193,7 @@ export function getApproveCheckedInstruction<
       args as ApproveCheckedInstructionDataArgs
     ),
   } as ApproveCheckedInstruction<
-    typeof TOKEN_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountSource,
     TAccountMint,
     TAccountDelegate,

--- a/clients/js/src/generated/instructions/burn.ts
+++ b/clients/js/src/generated/instructions/burn.ts
@@ -33,6 +33,12 @@ import {
 import { TOKEN_PROGRAM_ADDRESS } from '../programs';
 import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
 
+export const BURN_DISCRIMINATOR = 8;
+
+export function getBurnDiscriminatorBytes() {
+  return getU8Encoder().encode(BURN_DISCRIMINATOR);
+}
+
 export type BurnInstruction<
   TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
   TAccountAccount extends string | IAccountMeta<string> = string,
@@ -70,7 +76,7 @@ export function getBurnInstructionDataEncoder(): Encoder<BurnInstructionDataArgs
       ['discriminator', getU8Encoder()],
       ['amount', getU64Encoder()],
     ]),
-    (value) => ({ ...value, discriminator: 8 })
+    (value) => ({ ...value, discriminator: BURN_DISCRIMINATOR })
   );
 }
 
@@ -110,10 +116,12 @@ export function getBurnInstruction<
   TAccountAccount extends string,
   TAccountMint extends string,
   TAccountAuthority extends string,
+  TProgramAddress extends Address = typeof TOKEN_PROGRAM_ADDRESS,
 >(
-  input: BurnInput<TAccountAccount, TAccountMint, TAccountAuthority>
+  input: BurnInput<TAccountAccount, TAccountMint, TAccountAuthority>,
+  config?: { programAddress?: TProgramAddress }
 ): BurnInstruction<
-  typeof TOKEN_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountAccount,
   TAccountMint,
   (typeof input)['authority'] extends TransactionSigner<TAccountAuthority>
@@ -122,7 +130,7 @@ export function getBurnInstruction<
     : TAccountAuthority
 > {
   // Program address.
-  const programAddress = TOKEN_PROGRAM_ADDRESS;
+  const programAddress = config?.programAddress ?? TOKEN_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -160,7 +168,7 @@ export function getBurnInstruction<
       args as BurnInstructionDataArgs
     ),
   } as BurnInstruction<
-    typeof TOKEN_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountAccount,
     TAccountMint,
     (typeof input)['authority'] extends TransactionSigner<TAccountAuthority>

--- a/clients/js/src/generated/instructions/burnChecked.ts
+++ b/clients/js/src/generated/instructions/burnChecked.ts
@@ -33,6 +33,12 @@ import {
 import { TOKEN_PROGRAM_ADDRESS } from '../programs';
 import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
 
+export const BURN_CHECKED_DISCRIMINATOR = 15;
+
+export function getBurnCheckedDiscriminatorBytes() {
+  return getU8Encoder().encode(BURN_CHECKED_DISCRIMINATOR);
+}
+
 export type BurnCheckedInstruction<
   TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
   TAccountAccount extends string | IAccountMeta<string> = string,
@@ -78,7 +84,7 @@ export function getBurnCheckedInstructionDataEncoder(): Encoder<BurnCheckedInstr
       ['amount', getU64Encoder()],
       ['decimals', getU8Encoder()],
     ]),
-    (value) => ({ ...value, discriminator: 15 })
+    (value) => ({ ...value, discriminator: BURN_CHECKED_DISCRIMINATOR })
   );
 }
 
@@ -120,10 +126,12 @@ export function getBurnCheckedInstruction<
   TAccountAccount extends string,
   TAccountMint extends string,
   TAccountAuthority extends string,
+  TProgramAddress extends Address = typeof TOKEN_PROGRAM_ADDRESS,
 >(
-  input: BurnCheckedInput<TAccountAccount, TAccountMint, TAccountAuthority>
+  input: BurnCheckedInput<TAccountAccount, TAccountMint, TAccountAuthority>,
+  config?: { programAddress?: TProgramAddress }
 ): BurnCheckedInstruction<
-  typeof TOKEN_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountAccount,
   TAccountMint,
   (typeof input)['authority'] extends TransactionSigner<TAccountAuthority>
@@ -132,7 +140,7 @@ export function getBurnCheckedInstruction<
     : TAccountAuthority
 > {
   // Program address.
-  const programAddress = TOKEN_PROGRAM_ADDRESS;
+  const programAddress = config?.programAddress ?? TOKEN_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -170,7 +178,7 @@ export function getBurnCheckedInstruction<
       args as BurnCheckedInstructionDataArgs
     ),
   } as BurnCheckedInstruction<
-    typeof TOKEN_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountAccount,
     TAccountMint,
     (typeof input)['authority'] extends TransactionSigner<TAccountAuthority>

--- a/clients/js/src/generated/instructions/closeAccount.ts
+++ b/clients/js/src/generated/instructions/closeAccount.ts
@@ -31,6 +31,12 @@ import {
 import { TOKEN_PROGRAM_ADDRESS } from '../programs';
 import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
 
+export const CLOSE_ACCOUNT_DISCRIMINATOR = 9;
+
+export function getCloseAccountDiscriminatorBytes() {
+  return getU8Encoder().encode(CLOSE_ACCOUNT_DISCRIMINATOR);
+}
+
 export type CloseAccountInstruction<
   TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
   TAccountAccount extends string | IAccountMeta<string> = string,
@@ -61,7 +67,7 @@ export type CloseAccountInstructionDataArgs = {};
 export function getCloseAccountInstructionDataEncoder(): Encoder<CloseAccountInstructionDataArgs> {
   return transformEncoder(
     getStructEncoder([['discriminator', getU8Encoder()]]),
-    (value) => ({ ...value, discriminator: 9 })
+    (value) => ({ ...value, discriminator: CLOSE_ACCOUNT_DISCRIMINATOR })
   );
 }
 
@@ -97,10 +103,12 @@ export function getCloseAccountInstruction<
   TAccountAccount extends string,
   TAccountDestination extends string,
   TAccountOwner extends string,
+  TProgramAddress extends Address = typeof TOKEN_PROGRAM_ADDRESS,
 >(
-  input: CloseAccountInput<TAccountAccount, TAccountDestination, TAccountOwner>
+  input: CloseAccountInput<TAccountAccount, TAccountDestination, TAccountOwner>,
+  config?: { programAddress?: TProgramAddress }
 ): CloseAccountInstruction<
-  typeof TOKEN_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountAccount,
   TAccountDestination,
   (typeof input)['owner'] extends TransactionSigner<TAccountOwner>
@@ -108,7 +116,7 @@ export function getCloseAccountInstruction<
     : TAccountOwner
 > {
   // Program address.
-  const programAddress = TOKEN_PROGRAM_ADDRESS;
+  const programAddress = config?.programAddress ?? TOKEN_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -144,7 +152,7 @@ export function getCloseAccountInstruction<
     programAddress,
     data: getCloseAccountInstructionDataEncoder().encode({}),
   } as CloseAccountInstruction<
-    typeof TOKEN_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountAccount,
     TAccountDestination,
     (typeof input)['owner'] extends TransactionSigner<TAccountOwner>

--- a/clients/js/src/generated/instructions/createAssociatedToken.ts
+++ b/clients/js/src/generated/instructions/createAssociatedToken.ts
@@ -35,6 +35,12 @@ import {
   type ResolvedAccount,
 } from '../shared';
 
+export const CREATE_ASSOCIATED_TOKEN_DISCRIMINATOR = 0;
+
+export function getCreateAssociatedTokenDiscriminatorBytes() {
+  return getU8Encoder().encode(CREATE_ASSOCIATED_TOKEN_DISCRIMINATOR);
+}
+
 export type CreateAssociatedTokenInstruction<
   TProgram extends string = typeof ASSOCIATED_TOKEN_PROGRAM_ADDRESS,
   TAccountPayer extends string | IAccountMeta<string> = string,
@@ -80,7 +86,10 @@ export type CreateAssociatedTokenInstructionDataArgs = {};
 export function getCreateAssociatedTokenInstructionDataEncoder(): Encoder<CreateAssociatedTokenInstructionDataArgs> {
   return transformEncoder(
     getStructEncoder([['discriminator', getU8Encoder()]]),
-    (value) => ({ ...value, discriminator: 0 })
+    (value) => ({
+      ...value,
+      discriminator: CREATE_ASSOCIATED_TOKEN_DISCRIMINATOR,
+    })
   );
 }
 
@@ -127,6 +136,7 @@ export async function getCreateAssociatedTokenInstructionAsync<
   TAccountMint extends string,
   TAccountSystemProgram extends string,
   TAccountTokenProgram extends string,
+  TProgramAddress extends Address = typeof ASSOCIATED_TOKEN_PROGRAM_ADDRESS,
 >(
   input: CreateAssociatedTokenAsyncInput<
     TAccountPayer,
@@ -135,10 +145,11 @@ export async function getCreateAssociatedTokenInstructionAsync<
     TAccountMint,
     TAccountSystemProgram,
     TAccountTokenProgram
-  >
+  >,
+  config?: { programAddress?: TProgramAddress }
 ): Promise<
   CreateAssociatedTokenInstruction<
-    typeof ASSOCIATED_TOKEN_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountPayer,
     TAccountAta,
     TAccountOwner,
@@ -148,7 +159,8 @@ export async function getCreateAssociatedTokenInstructionAsync<
   >
 > {
   // Program address.
-  const programAddress = ASSOCIATED_TOKEN_PROGRAM_ADDRESS;
+  const programAddress =
+    config?.programAddress ?? ASSOCIATED_TOKEN_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -194,7 +206,7 @@ export async function getCreateAssociatedTokenInstructionAsync<
     programAddress,
     data: getCreateAssociatedTokenInstructionDataEncoder().encode({}),
   } as CreateAssociatedTokenInstruction<
-    typeof ASSOCIATED_TOKEN_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountPayer,
     TAccountAta,
     TAccountOwner,
@@ -235,6 +247,7 @@ export function getCreateAssociatedTokenInstruction<
   TAccountMint extends string,
   TAccountSystemProgram extends string,
   TAccountTokenProgram extends string,
+  TProgramAddress extends Address = typeof ASSOCIATED_TOKEN_PROGRAM_ADDRESS,
 >(
   input: CreateAssociatedTokenInput<
     TAccountPayer,
@@ -243,9 +256,10 @@ export function getCreateAssociatedTokenInstruction<
     TAccountMint,
     TAccountSystemProgram,
     TAccountTokenProgram
-  >
+  >,
+  config?: { programAddress?: TProgramAddress }
 ): CreateAssociatedTokenInstruction<
-  typeof ASSOCIATED_TOKEN_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountPayer,
   TAccountAta,
   TAccountOwner,
@@ -254,7 +268,8 @@ export function getCreateAssociatedTokenInstruction<
   TAccountTokenProgram
 > {
   // Program address.
-  const programAddress = ASSOCIATED_TOKEN_PROGRAM_ADDRESS;
+  const programAddress =
+    config?.programAddress ?? ASSOCIATED_TOKEN_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -293,7 +308,7 @@ export function getCreateAssociatedTokenInstruction<
     programAddress,
     data: getCreateAssociatedTokenInstructionDataEncoder().encode({}),
   } as CreateAssociatedTokenInstruction<
-    typeof ASSOCIATED_TOKEN_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountPayer,
     TAccountAta,
     TAccountOwner,

--- a/clients/js/src/generated/instructions/createAssociatedTokenIdempotent.ts
+++ b/clients/js/src/generated/instructions/createAssociatedTokenIdempotent.ts
@@ -35,6 +35,14 @@ import {
   type ResolvedAccount,
 } from '../shared';
 
+export const CREATE_ASSOCIATED_TOKEN_IDEMPOTENT_DISCRIMINATOR = 1;
+
+export function getCreateAssociatedTokenIdempotentDiscriminatorBytes() {
+  return getU8Encoder().encode(
+    CREATE_ASSOCIATED_TOKEN_IDEMPOTENT_DISCRIMINATOR
+  );
+}
+
 export type CreateAssociatedTokenIdempotentInstruction<
   TProgram extends string = typeof ASSOCIATED_TOKEN_PROGRAM_ADDRESS,
   TAccountPayer extends string | IAccountMeta<string> = string,
@@ -82,7 +90,10 @@ export type CreateAssociatedTokenIdempotentInstructionDataArgs = {};
 export function getCreateAssociatedTokenIdempotentInstructionDataEncoder(): Encoder<CreateAssociatedTokenIdempotentInstructionDataArgs> {
   return transformEncoder(
     getStructEncoder([['discriminator', getU8Encoder()]]),
-    (value) => ({ ...value, discriminator: 1 })
+    (value) => ({
+      ...value,
+      discriminator: CREATE_ASSOCIATED_TOKEN_IDEMPOTENT_DISCRIMINATOR,
+    })
   );
 }
 
@@ -129,6 +140,7 @@ export async function getCreateAssociatedTokenIdempotentInstructionAsync<
   TAccountMint extends string,
   TAccountSystemProgram extends string,
   TAccountTokenProgram extends string,
+  TProgramAddress extends Address = typeof ASSOCIATED_TOKEN_PROGRAM_ADDRESS,
 >(
   input: CreateAssociatedTokenIdempotentAsyncInput<
     TAccountPayer,
@@ -137,10 +149,11 @@ export async function getCreateAssociatedTokenIdempotentInstructionAsync<
     TAccountMint,
     TAccountSystemProgram,
     TAccountTokenProgram
-  >
+  >,
+  config?: { programAddress?: TProgramAddress }
 ): Promise<
   CreateAssociatedTokenIdempotentInstruction<
-    typeof ASSOCIATED_TOKEN_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountPayer,
     TAccountAta,
     TAccountOwner,
@@ -150,7 +163,8 @@ export async function getCreateAssociatedTokenIdempotentInstructionAsync<
   >
 > {
   // Program address.
-  const programAddress = ASSOCIATED_TOKEN_PROGRAM_ADDRESS;
+  const programAddress =
+    config?.programAddress ?? ASSOCIATED_TOKEN_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -196,7 +210,7 @@ export async function getCreateAssociatedTokenIdempotentInstructionAsync<
     programAddress,
     data: getCreateAssociatedTokenIdempotentInstructionDataEncoder().encode({}),
   } as CreateAssociatedTokenIdempotentInstruction<
-    typeof ASSOCIATED_TOKEN_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountPayer,
     TAccountAta,
     TAccountOwner,
@@ -237,6 +251,7 @@ export function getCreateAssociatedTokenIdempotentInstruction<
   TAccountMint extends string,
   TAccountSystemProgram extends string,
   TAccountTokenProgram extends string,
+  TProgramAddress extends Address = typeof ASSOCIATED_TOKEN_PROGRAM_ADDRESS,
 >(
   input: CreateAssociatedTokenIdempotentInput<
     TAccountPayer,
@@ -245,9 +260,10 @@ export function getCreateAssociatedTokenIdempotentInstruction<
     TAccountMint,
     TAccountSystemProgram,
     TAccountTokenProgram
-  >
+  >,
+  config?: { programAddress?: TProgramAddress }
 ): CreateAssociatedTokenIdempotentInstruction<
-  typeof ASSOCIATED_TOKEN_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountPayer,
   TAccountAta,
   TAccountOwner,
@@ -256,7 +272,8 @@ export function getCreateAssociatedTokenIdempotentInstruction<
   TAccountTokenProgram
 > {
   // Program address.
-  const programAddress = ASSOCIATED_TOKEN_PROGRAM_ADDRESS;
+  const programAddress =
+    config?.programAddress ?? ASSOCIATED_TOKEN_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -295,7 +312,7 @@ export function getCreateAssociatedTokenIdempotentInstruction<
     programAddress,
     data: getCreateAssociatedTokenIdempotentInstructionDataEncoder().encode({}),
   } as CreateAssociatedTokenIdempotentInstruction<
-    typeof ASSOCIATED_TOKEN_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountPayer,
     TAccountAta,
     TAccountOwner,

--- a/clients/js/src/generated/instructions/freezeAccount.ts
+++ b/clients/js/src/generated/instructions/freezeAccount.ts
@@ -31,6 +31,12 @@ import {
 import { TOKEN_PROGRAM_ADDRESS } from '../programs';
 import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
 
+export const FREEZE_ACCOUNT_DISCRIMINATOR = 10;
+
+export function getFreezeAccountDiscriminatorBytes() {
+  return getU8Encoder().encode(FREEZE_ACCOUNT_DISCRIMINATOR);
+}
+
 export type FreezeAccountInstruction<
   TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
   TAccountAccount extends string | IAccountMeta<string> = string,
@@ -61,7 +67,7 @@ export type FreezeAccountInstructionDataArgs = {};
 export function getFreezeAccountInstructionDataEncoder(): Encoder<FreezeAccountInstructionDataArgs> {
   return transformEncoder(
     getStructEncoder([['discriminator', getU8Encoder()]]),
-    (value) => ({ ...value, discriminator: 10 })
+    (value) => ({ ...value, discriminator: FREEZE_ACCOUNT_DISCRIMINATOR })
   );
 }
 
@@ -97,10 +103,12 @@ export function getFreezeAccountInstruction<
   TAccountAccount extends string,
   TAccountMint extends string,
   TAccountOwner extends string,
+  TProgramAddress extends Address = typeof TOKEN_PROGRAM_ADDRESS,
 >(
-  input: FreezeAccountInput<TAccountAccount, TAccountMint, TAccountOwner>
+  input: FreezeAccountInput<TAccountAccount, TAccountMint, TAccountOwner>,
+  config?: { programAddress?: TProgramAddress }
 ): FreezeAccountInstruction<
-  typeof TOKEN_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountAccount,
   TAccountMint,
   (typeof input)['owner'] extends TransactionSigner<TAccountOwner>
@@ -108,7 +116,7 @@ export function getFreezeAccountInstruction<
     : TAccountOwner
 > {
   // Program address.
-  const programAddress = TOKEN_PROGRAM_ADDRESS;
+  const programAddress = config?.programAddress ?? TOKEN_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -144,7 +152,7 @@ export function getFreezeAccountInstruction<
     programAddress,
     data: getFreezeAccountInstructionDataEncoder().encode({}),
   } as FreezeAccountInstruction<
-    typeof TOKEN_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountAccount,
     TAccountMint,
     (typeof input)['owner'] extends TransactionSigner<TAccountOwner>

--- a/clients/js/src/generated/instructions/getAccountDataSize.ts
+++ b/clients/js/src/generated/instructions/getAccountDataSize.ts
@@ -26,6 +26,12 @@ import {
 import { TOKEN_PROGRAM_ADDRESS } from '../programs';
 import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
 
+export const GET_ACCOUNT_DATA_SIZE_DISCRIMINATOR = 21;
+
+export function getGetAccountDataSizeDiscriminatorBytes() {
+  return getU8Encoder().encode(GET_ACCOUNT_DATA_SIZE_DISCRIMINATOR);
+}
+
 export type GetAccountDataSizeInstruction<
   TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
   TAccountMint extends string | IAccountMeta<string> = string,
@@ -48,7 +54,10 @@ export type GetAccountDataSizeInstructionDataArgs = {};
 export function getGetAccountDataSizeInstructionDataEncoder(): Encoder<GetAccountDataSizeInstructionDataArgs> {
   return transformEncoder(
     getStructEncoder([['discriminator', getU8Encoder()]]),
-    (value) => ({ ...value, discriminator: 21 })
+    (value) => ({
+      ...value,
+      discriminator: GET_ACCOUNT_DATA_SIZE_DISCRIMINATOR,
+    })
   );
 }
 
@@ -71,11 +80,15 @@ export type GetAccountDataSizeInput<TAccountMint extends string = string> = {
   mint: Address<TAccountMint>;
 };
 
-export function getGetAccountDataSizeInstruction<TAccountMint extends string>(
-  input: GetAccountDataSizeInput<TAccountMint>
-): GetAccountDataSizeInstruction<typeof TOKEN_PROGRAM_ADDRESS, TAccountMint> {
+export function getGetAccountDataSizeInstruction<
+  TAccountMint extends string,
+  TProgramAddress extends Address = typeof TOKEN_PROGRAM_ADDRESS,
+>(
+  input: GetAccountDataSizeInput<TAccountMint>,
+  config?: { programAddress?: TProgramAddress }
+): GetAccountDataSizeInstruction<TProgramAddress, TAccountMint> {
   // Program address.
-  const programAddress = TOKEN_PROGRAM_ADDRESS;
+  const programAddress = config?.programAddress ?? TOKEN_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -91,10 +104,7 @@ export function getGetAccountDataSizeInstruction<TAccountMint extends string>(
     accounts: [getAccountMeta(accounts.mint)],
     programAddress,
     data: getGetAccountDataSizeInstructionDataEncoder().encode({}),
-  } as GetAccountDataSizeInstruction<
-    typeof TOKEN_PROGRAM_ADDRESS,
-    TAccountMint
-  >;
+  } as GetAccountDataSizeInstruction<TProgramAddress, TAccountMint>;
 
   return instruction;
 }

--- a/clients/js/src/generated/instructions/initializeAccount.ts
+++ b/clients/js/src/generated/instructions/initializeAccount.ts
@@ -27,6 +27,12 @@ import {
 import { TOKEN_PROGRAM_ADDRESS } from '../programs';
 import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
 
+export const INITIALIZE_ACCOUNT_DISCRIMINATOR = 1;
+
+export function getInitializeAccountDiscriminatorBytes() {
+  return getU8Encoder().encode(INITIALIZE_ACCOUNT_DISCRIMINATOR);
+}
+
 export type InitializeAccountInstruction<
   TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
   TAccountAccount extends string | IAccountMeta<string> = string,
@@ -63,7 +69,7 @@ export type InitializeAccountInstructionDataArgs = {};
 export function getInitializeAccountInstructionDataEncoder(): Encoder<InitializeAccountInstructionDataArgs> {
   return transformEncoder(
     getStructEncoder([['discriminator', getU8Encoder()]]),
-    (value) => ({ ...value, discriminator: 1 })
+    (value) => ({ ...value, discriminator: INITIALIZE_ACCOUNT_DISCRIMINATOR })
   );
 }
 
@@ -102,22 +108,24 @@ export function getInitializeAccountInstruction<
   TAccountMint extends string,
   TAccountOwner extends string,
   TAccountRent extends string,
+  TProgramAddress extends Address = typeof TOKEN_PROGRAM_ADDRESS,
 >(
   input: InitializeAccountInput<
     TAccountAccount,
     TAccountMint,
     TAccountOwner,
     TAccountRent
-  >
+  >,
+  config?: { programAddress?: TProgramAddress }
 ): InitializeAccountInstruction<
-  typeof TOKEN_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountAccount,
   TAccountMint,
   TAccountOwner,
   TAccountRent
 > {
   // Program address.
-  const programAddress = TOKEN_PROGRAM_ADDRESS;
+  const programAddress = config?.programAddress ?? TOKEN_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -148,7 +156,7 @@ export function getInitializeAccountInstruction<
     programAddress,
     data: getInitializeAccountInstructionDataEncoder().encode({}),
   } as InitializeAccountInstruction<
-    typeof TOKEN_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountAccount,
     TAccountMint,
     TAccountOwner,

--- a/clients/js/src/generated/instructions/initializeAccount2.ts
+++ b/clients/js/src/generated/instructions/initializeAccount2.ts
@@ -29,6 +29,12 @@ import {
 import { TOKEN_PROGRAM_ADDRESS } from '../programs';
 import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
 
+export const INITIALIZE_ACCOUNT2_DISCRIMINATOR = 16;
+
+export function getInitializeAccount2DiscriminatorBytes() {
+  return getU8Encoder().encode(INITIALIZE_ACCOUNT2_DISCRIMINATOR);
+}
+
 export type InitializeAccount2Instruction<
   TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
   TAccountAccount extends string | IAccountMeta<string> = string,
@@ -71,7 +77,7 @@ export function getInitializeAccount2InstructionDataEncoder(): Encoder<Initializ
       ['discriminator', getU8Encoder()],
       ['owner', getAddressEncoder()],
     ]),
-    (value) => ({ ...value, discriminator: 16 })
+    (value) => ({ ...value, discriminator: INITIALIZE_ACCOUNT2_DISCRIMINATOR })
   );
 }
 
@@ -110,16 +116,18 @@ export function getInitializeAccount2Instruction<
   TAccountAccount extends string,
   TAccountMint extends string,
   TAccountRent extends string,
+  TProgramAddress extends Address = typeof TOKEN_PROGRAM_ADDRESS,
 >(
-  input: InitializeAccount2Input<TAccountAccount, TAccountMint, TAccountRent>
+  input: InitializeAccount2Input<TAccountAccount, TAccountMint, TAccountRent>,
+  config?: { programAddress?: TProgramAddress }
 ): InitializeAccount2Instruction<
-  typeof TOKEN_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountAccount,
   TAccountMint,
   TAccountRent
 > {
   // Program address.
-  const programAddress = TOKEN_PROGRAM_ADDRESS;
+  const programAddress = config?.programAddress ?? TOKEN_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -153,7 +161,7 @@ export function getInitializeAccount2Instruction<
       args as InitializeAccount2InstructionDataArgs
     ),
   } as InitializeAccount2Instruction<
-    typeof TOKEN_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountAccount,
     TAccountMint,
     TAccountRent

--- a/clients/js/src/generated/instructions/initializeAccount3.ts
+++ b/clients/js/src/generated/instructions/initializeAccount3.ts
@@ -29,6 +29,12 @@ import {
 import { TOKEN_PROGRAM_ADDRESS } from '../programs';
 import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
 
+export const INITIALIZE_ACCOUNT3_DISCRIMINATOR = 18;
+
+export function getInitializeAccount3DiscriminatorBytes() {
+  return getU8Encoder().encode(INITIALIZE_ACCOUNT3_DISCRIMINATOR);
+}
+
 export type InitializeAccount3Instruction<
   TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
   TAccountAccount extends string | IAccountMeta<string> = string,
@@ -65,7 +71,7 @@ export function getInitializeAccount3InstructionDataEncoder(): Encoder<Initializ
       ['discriminator', getU8Encoder()],
       ['owner', getAddressEncoder()],
     ]),
-    (value) => ({ ...value, discriminator: 18 })
+    (value) => ({ ...value, discriminator: INITIALIZE_ACCOUNT3_DISCRIMINATOR })
   );
 }
 
@@ -100,15 +106,17 @@ export type InitializeAccount3Input<
 export function getInitializeAccount3Instruction<
   TAccountAccount extends string,
   TAccountMint extends string,
+  TProgramAddress extends Address = typeof TOKEN_PROGRAM_ADDRESS,
 >(
-  input: InitializeAccount3Input<TAccountAccount, TAccountMint>
+  input: InitializeAccount3Input<TAccountAccount, TAccountMint>,
+  config?: { programAddress?: TProgramAddress }
 ): InitializeAccount3Instruction<
-  typeof TOKEN_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountAccount,
   TAccountMint
 > {
   // Program address.
-  const programAddress = TOKEN_PROGRAM_ADDRESS;
+  const programAddress = config?.programAddress ?? TOKEN_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -131,7 +139,7 @@ export function getInitializeAccount3Instruction<
       args as InitializeAccount3InstructionDataArgs
     ),
   } as InitializeAccount3Instruction<
-    typeof TOKEN_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountAccount,
     TAccountMint
   >;

--- a/clients/js/src/generated/instructions/initializeImmutableOwner.ts
+++ b/clients/js/src/generated/instructions/initializeImmutableOwner.ts
@@ -26,6 +26,12 @@ import {
 import { TOKEN_PROGRAM_ADDRESS } from '../programs';
 import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
 
+export const INITIALIZE_IMMUTABLE_OWNER_DISCRIMINATOR = 22;
+
+export function getInitializeImmutableOwnerDiscriminatorBytes() {
+  return getU8Encoder().encode(INITIALIZE_IMMUTABLE_OWNER_DISCRIMINATOR);
+}
+
 export type InitializeImmutableOwnerInstruction<
   TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
   TAccountAccount extends string | IAccountMeta<string> = string,
@@ -48,7 +54,10 @@ export type InitializeImmutableOwnerInstructionDataArgs = {};
 export function getInitializeImmutableOwnerInstructionDataEncoder(): Encoder<InitializeImmutableOwnerInstructionDataArgs> {
   return transformEncoder(
     getStructEncoder([['discriminator', getU8Encoder()]]),
-    (value) => ({ ...value, discriminator: 22 })
+    (value) => ({
+      ...value,
+      discriminator: INITIALIZE_IMMUTABLE_OWNER_DISCRIMINATOR,
+    })
   );
 }
 
@@ -75,14 +84,13 @@ export type InitializeImmutableOwnerInput<
 
 export function getInitializeImmutableOwnerInstruction<
   TAccountAccount extends string,
+  TProgramAddress extends Address = typeof TOKEN_PROGRAM_ADDRESS,
 >(
-  input: InitializeImmutableOwnerInput<TAccountAccount>
-): InitializeImmutableOwnerInstruction<
-  typeof TOKEN_PROGRAM_ADDRESS,
-  TAccountAccount
-> {
+  input: InitializeImmutableOwnerInput<TAccountAccount>,
+  config?: { programAddress?: TProgramAddress }
+): InitializeImmutableOwnerInstruction<TProgramAddress, TAccountAccount> {
   // Program address.
-  const programAddress = TOKEN_PROGRAM_ADDRESS;
+  const programAddress = config?.programAddress ?? TOKEN_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -98,10 +106,7 @@ export function getInitializeImmutableOwnerInstruction<
     accounts: [getAccountMeta(accounts.account)],
     programAddress,
     data: getInitializeImmutableOwnerInstructionDataEncoder().encode({}),
-  } as InitializeImmutableOwnerInstruction<
-    typeof TOKEN_PROGRAM_ADDRESS,
-    TAccountAccount
-  >;
+  } as InitializeImmutableOwnerInstruction<TProgramAddress, TAccountAccount>;
 
   return instruction;
 }

--- a/clients/js/src/generated/instructions/initializeMint.ts
+++ b/clients/js/src/generated/instructions/initializeMint.ts
@@ -34,6 +34,12 @@ import {
 import { TOKEN_PROGRAM_ADDRESS } from '../programs';
 import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
 
+export const INITIALIZE_MINT_DISCRIMINATOR = 0;
+
+export function getInitializeMintDiscriminatorBytes() {
+  return getU8Encoder().encode(INITIALIZE_MINT_DISCRIMINATOR);
+}
+
 export type InitializeMintInstruction<
   TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
   TAccountMint extends string | IAccountMeta<string> = string,
@@ -84,7 +90,7 @@ export function getInitializeMintInstructionDataEncoder(): Encoder<InitializeMin
     ]),
     (value) => ({
       ...value,
-      discriminator: 0,
+      discriminator: INITIALIZE_MINT_DISCRIMINATOR,
       freezeAuthority: value.freezeAuthority ?? none(),
     })
   );
@@ -125,15 +131,13 @@ export type InitializeMintInput<
 export function getInitializeMintInstruction<
   TAccountMint extends string,
   TAccountRent extends string,
+  TProgramAddress extends Address = typeof TOKEN_PROGRAM_ADDRESS,
 >(
-  input: InitializeMintInput<TAccountMint, TAccountRent>
-): InitializeMintInstruction<
-  typeof TOKEN_PROGRAM_ADDRESS,
-  TAccountMint,
-  TAccountRent
-> {
+  input: InitializeMintInput<TAccountMint, TAccountRent>,
+  config?: { programAddress?: TProgramAddress }
+): InitializeMintInstruction<TProgramAddress, TAccountMint, TAccountRent> {
   // Program address.
-  const programAddress = TOKEN_PROGRAM_ADDRESS;
+  const programAddress = config?.programAddress ?? TOKEN_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -161,11 +165,7 @@ export function getInitializeMintInstruction<
     data: getInitializeMintInstructionDataEncoder().encode(
       args as InitializeMintInstructionDataArgs
     ),
-  } as InitializeMintInstruction<
-    typeof TOKEN_PROGRAM_ADDRESS,
-    TAccountMint,
-    TAccountRent
-  >;
+  } as InitializeMintInstruction<TProgramAddress, TAccountMint, TAccountRent>;
 
   return instruction;
 }

--- a/clients/js/src/generated/instructions/initializeMint2.ts
+++ b/clients/js/src/generated/instructions/initializeMint2.ts
@@ -33,6 +33,12 @@ import {
 import { TOKEN_PROGRAM_ADDRESS } from '../programs';
 import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
 
+export const INITIALIZE_MINT2_DISCRIMINATOR = 20;
+
+export function getInitializeMint2DiscriminatorBytes() {
+  return getU8Encoder().encode(INITIALIZE_MINT2_DISCRIMINATOR);
+}
+
 export type InitializeMint2Instruction<
   TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
   TAccountMint extends string | IAccountMeta<string> = string,
@@ -77,7 +83,7 @@ export function getInitializeMint2InstructionDataEncoder(): Encoder<InitializeMi
     ]),
     (value) => ({
       ...value,
-      discriminator: 20,
+      discriminator: INITIALIZE_MINT2_DISCRIMINATOR,
       freezeAuthority: value.freezeAuthority ?? none(),
     })
   );
@@ -110,11 +116,15 @@ export type InitializeMint2Input<TAccountMint extends string = string> = {
   freezeAuthority?: InitializeMint2InstructionDataArgs['freezeAuthority'];
 };
 
-export function getInitializeMint2Instruction<TAccountMint extends string>(
-  input: InitializeMint2Input<TAccountMint>
-): InitializeMint2Instruction<typeof TOKEN_PROGRAM_ADDRESS, TAccountMint> {
+export function getInitializeMint2Instruction<
+  TAccountMint extends string,
+  TProgramAddress extends Address = typeof TOKEN_PROGRAM_ADDRESS,
+>(
+  input: InitializeMint2Input<TAccountMint>,
+  config?: { programAddress?: TProgramAddress }
+): InitializeMint2Instruction<TProgramAddress, TAccountMint> {
   // Program address.
-  const programAddress = TOKEN_PROGRAM_ADDRESS;
+  const programAddress = config?.programAddress ?? TOKEN_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -135,7 +145,7 @@ export function getInitializeMint2Instruction<TAccountMint extends string>(
     data: getInitializeMint2InstructionDataEncoder().encode(
       args as InitializeMint2InstructionDataArgs
     ),
-  } as InitializeMint2Instruction<typeof TOKEN_PROGRAM_ADDRESS, TAccountMint>;
+  } as InitializeMint2Instruction<TProgramAddress, TAccountMint>;
 
   return instruction;
 }

--- a/clients/js/src/generated/instructions/initializeMultisig.ts
+++ b/clients/js/src/generated/instructions/initializeMultisig.ts
@@ -28,6 +28,12 @@ import {
 import { TOKEN_PROGRAM_ADDRESS } from '../programs';
 import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
 
+export const INITIALIZE_MULTISIG_DISCRIMINATOR = 2;
+
+export function getInitializeMultisigDiscriminatorBytes() {
+  return getU8Encoder().encode(INITIALIZE_MULTISIG_DISCRIMINATOR);
+}
+
 export type InitializeMultisigInstruction<
   TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
   TAccountMultisig extends string | IAccountMeta<string> = string,
@@ -66,7 +72,7 @@ export function getInitializeMultisigInstructionDataEncoder(): Encoder<Initializ
       ['discriminator', getU8Encoder()],
       ['m', getU8Encoder()],
     ]),
-    (value) => ({ ...value, discriminator: 2 })
+    (value) => ({ ...value, discriminator: INITIALIZE_MULTISIG_DISCRIMINATOR })
   );
 }
 
@@ -102,15 +108,17 @@ export type InitializeMultisigInput<
 export function getInitializeMultisigInstruction<
   TAccountMultisig extends string,
   TAccountRent extends string,
+  TProgramAddress extends Address = typeof TOKEN_PROGRAM_ADDRESS,
 >(
-  input: InitializeMultisigInput<TAccountMultisig, TAccountRent>
+  input: InitializeMultisigInput<TAccountMultisig, TAccountRent>,
+  config?: { programAddress?: TProgramAddress }
 ): InitializeMultisigInstruction<
-  typeof TOKEN_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountMultisig,
   TAccountRent
 > {
   // Program address.
-  const programAddress = TOKEN_PROGRAM_ADDRESS;
+  const programAddress = config?.programAddress ?? TOKEN_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -149,7 +157,7 @@ export function getInitializeMultisigInstruction<
       args as InitializeMultisigInstructionDataArgs
     ),
   } as InitializeMultisigInstruction<
-    typeof TOKEN_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountMultisig,
     TAccountRent
   >;

--- a/clients/js/src/generated/instructions/initializeMultisig2.ts
+++ b/clients/js/src/generated/instructions/initializeMultisig2.ts
@@ -27,6 +27,12 @@ import {
 import { TOKEN_PROGRAM_ADDRESS } from '../programs';
 import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
 
+export const INITIALIZE_MULTISIG2_DISCRIMINATOR = 19;
+
+export function getInitializeMultisig2DiscriminatorBytes() {
+  return getU8Encoder().encode(INITIALIZE_MULTISIG2_DISCRIMINATOR);
+}
+
 export type InitializeMultisig2Instruction<
   TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
   TAccountMultisig extends string | IAccountMeta<string> = string,
@@ -59,7 +65,7 @@ export function getInitializeMultisig2InstructionDataEncoder(): Encoder<Initiali
       ['discriminator', getU8Encoder()],
       ['m', getU8Encoder()],
     ]),
-    (value) => ({ ...value, discriminator: 19 })
+    (value) => ({ ...value, discriminator: INITIALIZE_MULTISIG2_DISCRIMINATOR })
   );
 }
 
@@ -90,14 +96,13 @@ export type InitializeMultisig2Input<TAccountMultisig extends string = string> =
 
 export function getInitializeMultisig2Instruction<
   TAccountMultisig extends string,
+  TProgramAddress extends Address = typeof TOKEN_PROGRAM_ADDRESS,
 >(
-  input: InitializeMultisig2Input<TAccountMultisig>
-): InitializeMultisig2Instruction<
-  typeof TOKEN_PROGRAM_ADDRESS,
-  TAccountMultisig
-> {
+  input: InitializeMultisig2Input<TAccountMultisig>,
+  config?: { programAddress?: TProgramAddress }
+): InitializeMultisig2Instruction<TProgramAddress, TAccountMultisig> {
   // Program address.
-  const programAddress = TOKEN_PROGRAM_ADDRESS;
+  const programAddress = config?.programAddress ?? TOKEN_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -124,10 +129,7 @@ export function getInitializeMultisig2Instruction<
     data: getInitializeMultisig2InstructionDataEncoder().encode(
       args as InitializeMultisig2InstructionDataArgs
     ),
-  } as InitializeMultisig2Instruction<
-    typeof TOKEN_PROGRAM_ADDRESS,
-    TAccountMultisig
-  >;
+  } as InitializeMultisig2Instruction<TProgramAddress, TAccountMultisig>;
 
   return instruction;
 }

--- a/clients/js/src/generated/instructions/mintTo.ts
+++ b/clients/js/src/generated/instructions/mintTo.ts
@@ -33,6 +33,12 @@ import {
 import { TOKEN_PROGRAM_ADDRESS } from '../programs';
 import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
 
+export const MINT_TO_DISCRIMINATOR = 7;
+
+export function getMintToDiscriminatorBytes() {
+  return getU8Encoder().encode(MINT_TO_DISCRIMINATOR);
+}
+
 export type MintToInstruction<
   TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
   TAccountMint extends string | IAccountMeta<string> = string,
@@ -73,7 +79,7 @@ export function getMintToInstructionDataEncoder(): Encoder<MintToInstructionData
       ['discriminator', getU8Encoder()],
       ['amount', getU64Encoder()],
     ]),
-    (value) => ({ ...value, discriminator: 7 })
+    (value) => ({ ...value, discriminator: MINT_TO_DISCRIMINATOR })
   );
 }
 
@@ -115,10 +121,12 @@ export function getMintToInstruction<
   TAccountMint extends string,
   TAccountToken extends string,
   TAccountMintAuthority extends string,
+  TProgramAddress extends Address = typeof TOKEN_PROGRAM_ADDRESS,
 >(
-  input: MintToInput<TAccountMint, TAccountToken, TAccountMintAuthority>
+  input: MintToInput<TAccountMint, TAccountToken, TAccountMintAuthority>,
+  config?: { programAddress?: TProgramAddress }
 ): MintToInstruction<
-  typeof TOKEN_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountMint,
   TAccountToken,
   (typeof input)['mintAuthority'] extends TransactionSigner<TAccountMintAuthority>
@@ -127,7 +135,7 @@ export function getMintToInstruction<
     : TAccountMintAuthority
 > {
   // Program address.
-  const programAddress = TOKEN_PROGRAM_ADDRESS;
+  const programAddress = config?.programAddress ?? TOKEN_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -165,7 +173,7 @@ export function getMintToInstruction<
       args as MintToInstructionDataArgs
     ),
   } as MintToInstruction<
-    typeof TOKEN_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountMint,
     TAccountToken,
     (typeof input)['mintAuthority'] extends TransactionSigner<TAccountMintAuthority>

--- a/clients/js/src/generated/instructions/mintToChecked.ts
+++ b/clients/js/src/generated/instructions/mintToChecked.ts
@@ -33,6 +33,12 @@ import {
 import { TOKEN_PROGRAM_ADDRESS } from '../programs';
 import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
 
+export const MINT_TO_CHECKED_DISCRIMINATOR = 14;
+
+export function getMintToCheckedDiscriminatorBytes() {
+  return getU8Encoder().encode(MINT_TO_CHECKED_DISCRIMINATOR);
+}
+
 export type MintToCheckedInstruction<
   TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
   TAccountMint extends string | IAccountMeta<string> = string,
@@ -78,7 +84,7 @@ export function getMintToCheckedInstructionDataEncoder(): Encoder<MintToCheckedI
       ['amount', getU64Encoder()],
       ['decimals', getU8Encoder()],
     ]),
-    (value) => ({ ...value, discriminator: 14 })
+    (value) => ({ ...value, discriminator: MINT_TO_CHECKED_DISCRIMINATOR })
   );
 }
 
@@ -122,10 +128,12 @@ export function getMintToCheckedInstruction<
   TAccountMint extends string,
   TAccountToken extends string,
   TAccountMintAuthority extends string,
+  TProgramAddress extends Address = typeof TOKEN_PROGRAM_ADDRESS,
 >(
-  input: MintToCheckedInput<TAccountMint, TAccountToken, TAccountMintAuthority>
+  input: MintToCheckedInput<TAccountMint, TAccountToken, TAccountMintAuthority>,
+  config?: { programAddress?: TProgramAddress }
 ): MintToCheckedInstruction<
-  typeof TOKEN_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountMint,
   TAccountToken,
   (typeof input)['mintAuthority'] extends TransactionSigner<TAccountMintAuthority>
@@ -134,7 +142,7 @@ export function getMintToCheckedInstruction<
     : TAccountMintAuthority
 > {
   // Program address.
-  const programAddress = TOKEN_PROGRAM_ADDRESS;
+  const programAddress = config?.programAddress ?? TOKEN_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -172,7 +180,7 @@ export function getMintToCheckedInstruction<
       args as MintToCheckedInstructionDataArgs
     ),
   } as MintToCheckedInstruction<
-    typeof TOKEN_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountMint,
     TAccountToken,
     (typeof input)['mintAuthority'] extends TransactionSigner<TAccountMintAuthority>

--- a/clients/js/src/generated/instructions/recoverNestedAssociatedToken.ts
+++ b/clients/js/src/generated/instructions/recoverNestedAssociatedToken.ts
@@ -35,6 +35,12 @@ import {
   type ResolvedAccount,
 } from '../shared';
 
+export const RECOVER_NESTED_ASSOCIATED_TOKEN_DISCRIMINATOR = 2;
+
+export function getRecoverNestedAssociatedTokenDiscriminatorBytes() {
+  return getU8Encoder().encode(RECOVER_NESTED_ASSOCIATED_TOKEN_DISCRIMINATOR);
+}
+
 export type RecoverNestedAssociatedTokenInstruction<
   TProgram extends string = typeof ASSOCIATED_TOKEN_PROGRAM_ADDRESS,
   TAccountNestedAssociatedAccountAddress extends
@@ -92,7 +98,10 @@ export type RecoverNestedAssociatedTokenInstructionDataArgs = {};
 export function getRecoverNestedAssociatedTokenInstructionDataEncoder(): Encoder<RecoverNestedAssociatedTokenInstructionDataArgs> {
   return transformEncoder(
     getStructEncoder([['discriminator', getU8Encoder()]]),
-    (value) => ({ ...value, discriminator: 2 })
+    (value) => ({
+      ...value,
+      discriminator: RECOVER_NESTED_ASSOCIATED_TOKEN_DISCRIMINATOR,
+    })
   );
 }
 
@@ -143,6 +152,7 @@ export async function getRecoverNestedAssociatedTokenInstructionAsync<
   TAccountOwnerTokenMintAddress extends string,
   TAccountWalletAddress extends string,
   TAccountTokenProgram extends string,
+  TProgramAddress extends Address = typeof ASSOCIATED_TOKEN_PROGRAM_ADDRESS,
 >(
   input: RecoverNestedAssociatedTokenAsyncInput<
     TAccountNestedAssociatedAccountAddress,
@@ -152,10 +162,11 @@ export async function getRecoverNestedAssociatedTokenInstructionAsync<
     TAccountOwnerTokenMintAddress,
     TAccountWalletAddress,
     TAccountTokenProgram
-  >
+  >,
+  config?: { programAddress?: TProgramAddress }
 ): Promise<
   RecoverNestedAssociatedTokenInstruction<
-    typeof ASSOCIATED_TOKEN_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountNestedAssociatedAccountAddress,
     TAccountNestedTokenMintAddress,
     TAccountDestinationAssociatedAccountAddress,
@@ -166,7 +177,8 @@ export async function getRecoverNestedAssociatedTokenInstructionAsync<
   >
 > {
   // Program address.
-  const programAddress = ASSOCIATED_TOKEN_PROGRAM_ADDRESS;
+  const programAddress =
+    config?.programAddress ?? ASSOCIATED_TOKEN_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -243,7 +255,7 @@ export async function getRecoverNestedAssociatedTokenInstructionAsync<
     programAddress,
     data: getRecoverNestedAssociatedTokenInstructionDataEncoder().encode({}),
   } as RecoverNestedAssociatedTokenInstruction<
-    typeof ASSOCIATED_TOKEN_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountNestedAssociatedAccountAddress,
     TAccountNestedTokenMintAddress,
     TAccountDestinationAssociatedAccountAddress,
@@ -289,6 +301,7 @@ export function getRecoverNestedAssociatedTokenInstruction<
   TAccountOwnerTokenMintAddress extends string,
   TAccountWalletAddress extends string,
   TAccountTokenProgram extends string,
+  TProgramAddress extends Address = typeof ASSOCIATED_TOKEN_PROGRAM_ADDRESS,
 >(
   input: RecoverNestedAssociatedTokenInput<
     TAccountNestedAssociatedAccountAddress,
@@ -298,9 +311,10 @@ export function getRecoverNestedAssociatedTokenInstruction<
     TAccountOwnerTokenMintAddress,
     TAccountWalletAddress,
     TAccountTokenProgram
-  >
+  >,
+  config?: { programAddress?: TProgramAddress }
 ): RecoverNestedAssociatedTokenInstruction<
-  typeof ASSOCIATED_TOKEN_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountNestedAssociatedAccountAddress,
   TAccountNestedTokenMintAddress,
   TAccountDestinationAssociatedAccountAddress,
@@ -310,7 +324,8 @@ export function getRecoverNestedAssociatedTokenInstruction<
   TAccountTokenProgram
 > {
   // Program address.
-  const programAddress = ASSOCIATED_TOKEN_PROGRAM_ADDRESS;
+  const programAddress =
+    config?.programAddress ?? ASSOCIATED_TOKEN_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -362,7 +377,7 @@ export function getRecoverNestedAssociatedTokenInstruction<
     programAddress,
     data: getRecoverNestedAssociatedTokenInstructionDataEncoder().encode({}),
   } as RecoverNestedAssociatedTokenInstruction<
-    typeof ASSOCIATED_TOKEN_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountNestedAssociatedAccountAddress,
     TAccountNestedTokenMintAddress,
     TAccountDestinationAssociatedAccountAddress,

--- a/clients/js/src/generated/instructions/revoke.ts
+++ b/clients/js/src/generated/instructions/revoke.ts
@@ -31,6 +31,12 @@ import {
 import { TOKEN_PROGRAM_ADDRESS } from '../programs';
 import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
 
+export const REVOKE_DISCRIMINATOR = 5;
+
+export function getRevokeDiscriminatorBytes() {
+  return getU8Encoder().encode(REVOKE_DISCRIMINATOR);
+}
+
 export type RevokeInstruction<
   TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
   TAccountSource extends string | IAccountMeta<string> = string,
@@ -57,7 +63,7 @@ export type RevokeInstructionDataArgs = {};
 export function getRevokeInstructionDataEncoder(): Encoder<RevokeInstructionDataArgs> {
   return transformEncoder(
     getStructEncoder([['discriminator', getU8Encoder()]]),
-    (value) => ({ ...value, discriminator: 5 })
+    (value) => ({ ...value, discriminator: REVOKE_DISCRIMINATOR })
   );
 }
 
@@ -89,17 +95,19 @@ export type RevokeInput<
 export function getRevokeInstruction<
   TAccountSource extends string,
   TAccountOwner extends string,
+  TProgramAddress extends Address = typeof TOKEN_PROGRAM_ADDRESS,
 >(
-  input: RevokeInput<TAccountSource, TAccountOwner>
+  input: RevokeInput<TAccountSource, TAccountOwner>,
+  config?: { programAddress?: TProgramAddress }
 ): RevokeInstruction<
-  typeof TOKEN_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountSource,
   (typeof input)['owner'] extends TransactionSigner<TAccountOwner>
     ? ReadonlySignerAccount<TAccountOwner> & IAccountSignerMeta<TAccountOwner>
     : TAccountOwner
 > {
   // Program address.
-  const programAddress = TOKEN_PROGRAM_ADDRESS;
+  const programAddress = config?.programAddress ?? TOKEN_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -133,7 +141,7 @@ export function getRevokeInstruction<
     programAddress,
     data: getRevokeInstructionDataEncoder().encode({}),
   } as RevokeInstruction<
-    typeof TOKEN_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountSource,
     (typeof input)['owner'] extends TransactionSigner<TAccountOwner>
       ? ReadonlySignerAccount<TAccountOwner> & IAccountSignerMeta<TAccountOwner>

--- a/clients/js/src/generated/instructions/setAuthority.ts
+++ b/clients/js/src/generated/instructions/setAuthority.ts
@@ -43,6 +43,12 @@ import {
   type AuthorityTypeArgs,
 } from '../types';
 
+export const SET_AUTHORITY_DISCRIMINATOR = 6;
+
+export function getSetAuthorityDiscriminatorBytes() {
+  return getU8Encoder().encode(SET_AUTHORITY_DISCRIMINATOR);
+}
+
 export type SetAuthorityInstruction<
   TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
   TAccountOwned extends string | IAccountMeta<string> = string,
@@ -84,7 +90,7 @@ export function getSetAuthorityInstructionDataEncoder(): Encoder<SetAuthorityIns
       ['authorityType', getAuthorityTypeEncoder()],
       ['newAuthority', getOptionEncoder(getAddressEncoder())],
     ]),
-    (value) => ({ ...value, discriminator: 6 })
+    (value) => ({ ...value, discriminator: SET_AUTHORITY_DISCRIMINATOR })
   );
 }
 
@@ -122,17 +128,19 @@ export type SetAuthorityInput<
 export function getSetAuthorityInstruction<
   TAccountOwned extends string,
   TAccountOwner extends string,
+  TProgramAddress extends Address = typeof TOKEN_PROGRAM_ADDRESS,
 >(
-  input: SetAuthorityInput<TAccountOwned, TAccountOwner>
+  input: SetAuthorityInput<TAccountOwned, TAccountOwner>,
+  config?: { programAddress?: TProgramAddress }
 ): SetAuthorityInstruction<
-  typeof TOKEN_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountOwned,
   (typeof input)['owner'] extends TransactionSigner<TAccountOwner>
     ? ReadonlySignerAccount<TAccountOwner> & IAccountSignerMeta<TAccountOwner>
     : TAccountOwner
 > {
   // Program address.
-  const programAddress = TOKEN_PROGRAM_ADDRESS;
+  const programAddress = config?.programAddress ?? TOKEN_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -168,7 +176,7 @@ export function getSetAuthorityInstruction<
       args as SetAuthorityInstructionDataArgs
     ),
   } as SetAuthorityInstruction<
-    typeof TOKEN_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountOwned,
     (typeof input)['owner'] extends TransactionSigner<TAccountOwner>
       ? ReadonlySignerAccount<TAccountOwner> & IAccountSignerMeta<TAccountOwner>

--- a/clients/js/src/generated/instructions/syncNative.ts
+++ b/clients/js/src/generated/instructions/syncNative.ts
@@ -26,6 +26,12 @@ import {
 import { TOKEN_PROGRAM_ADDRESS } from '../programs';
 import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
 
+export const SYNC_NATIVE_DISCRIMINATOR = 17;
+
+export function getSyncNativeDiscriminatorBytes() {
+  return getU8Encoder().encode(SYNC_NATIVE_DISCRIMINATOR);
+}
+
 export type SyncNativeInstruction<
   TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
   TAccountAccount extends string | IAccountMeta<string> = string,
@@ -48,7 +54,7 @@ export type SyncNativeInstructionDataArgs = {};
 export function getSyncNativeInstructionDataEncoder(): Encoder<SyncNativeInstructionDataArgs> {
   return transformEncoder(
     getStructEncoder([['discriminator', getU8Encoder()]]),
-    (value) => ({ ...value, discriminator: 17 })
+    (value) => ({ ...value, discriminator: SYNC_NATIVE_DISCRIMINATOR })
   );
 }
 
@@ -71,11 +77,15 @@ export type SyncNativeInput<TAccountAccount extends string = string> = {
   account: Address<TAccountAccount>;
 };
 
-export function getSyncNativeInstruction<TAccountAccount extends string>(
-  input: SyncNativeInput<TAccountAccount>
-): SyncNativeInstruction<typeof TOKEN_PROGRAM_ADDRESS, TAccountAccount> {
+export function getSyncNativeInstruction<
+  TAccountAccount extends string,
+  TProgramAddress extends Address = typeof TOKEN_PROGRAM_ADDRESS,
+>(
+  input: SyncNativeInput<TAccountAccount>,
+  config?: { programAddress?: TProgramAddress }
+): SyncNativeInstruction<TProgramAddress, TAccountAccount> {
   // Program address.
-  const programAddress = TOKEN_PROGRAM_ADDRESS;
+  const programAddress = config?.programAddress ?? TOKEN_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -91,7 +101,7 @@ export function getSyncNativeInstruction<TAccountAccount extends string>(
     accounts: [getAccountMeta(accounts.account)],
     programAddress,
     data: getSyncNativeInstructionDataEncoder().encode({}),
-  } as SyncNativeInstruction<typeof TOKEN_PROGRAM_ADDRESS, TAccountAccount>;
+  } as SyncNativeInstruction<TProgramAddress, TAccountAccount>;
 
   return instruction;
 }

--- a/clients/js/src/generated/instructions/thawAccount.ts
+++ b/clients/js/src/generated/instructions/thawAccount.ts
@@ -31,6 +31,12 @@ import {
 import { TOKEN_PROGRAM_ADDRESS } from '../programs';
 import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
 
+export const THAW_ACCOUNT_DISCRIMINATOR = 11;
+
+export function getThawAccountDiscriminatorBytes() {
+  return getU8Encoder().encode(THAW_ACCOUNT_DISCRIMINATOR);
+}
+
 export type ThawAccountInstruction<
   TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
   TAccountAccount extends string | IAccountMeta<string> = string,
@@ -61,7 +67,7 @@ export type ThawAccountInstructionDataArgs = {};
 export function getThawAccountInstructionDataEncoder(): Encoder<ThawAccountInstructionDataArgs> {
   return transformEncoder(
     getStructEncoder([['discriminator', getU8Encoder()]]),
-    (value) => ({ ...value, discriminator: 11 })
+    (value) => ({ ...value, discriminator: THAW_ACCOUNT_DISCRIMINATOR })
   );
 }
 
@@ -97,10 +103,12 @@ export function getThawAccountInstruction<
   TAccountAccount extends string,
   TAccountMint extends string,
   TAccountOwner extends string,
+  TProgramAddress extends Address = typeof TOKEN_PROGRAM_ADDRESS,
 >(
-  input: ThawAccountInput<TAccountAccount, TAccountMint, TAccountOwner>
+  input: ThawAccountInput<TAccountAccount, TAccountMint, TAccountOwner>,
+  config?: { programAddress?: TProgramAddress }
 ): ThawAccountInstruction<
-  typeof TOKEN_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountAccount,
   TAccountMint,
   (typeof input)['owner'] extends TransactionSigner<TAccountOwner>
@@ -108,7 +116,7 @@ export function getThawAccountInstruction<
     : TAccountOwner
 > {
   // Program address.
-  const programAddress = TOKEN_PROGRAM_ADDRESS;
+  const programAddress = config?.programAddress ?? TOKEN_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -144,7 +152,7 @@ export function getThawAccountInstruction<
     programAddress,
     data: getThawAccountInstructionDataEncoder().encode({}),
   } as ThawAccountInstruction<
-    typeof TOKEN_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountAccount,
     TAccountMint,
     (typeof input)['owner'] extends TransactionSigner<TAccountOwner>

--- a/clients/js/src/generated/instructions/transferChecked.ts
+++ b/clients/js/src/generated/instructions/transferChecked.ts
@@ -33,6 +33,12 @@ import {
 import { TOKEN_PROGRAM_ADDRESS } from '../programs';
 import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
 
+export const TRANSFER_CHECKED_DISCRIMINATOR = 12;
+
+export function getTransferCheckedDiscriminatorBytes() {
+  return getU8Encoder().encode(TRANSFER_CHECKED_DISCRIMINATOR);
+}
+
 export type TransferCheckedInstruction<
   TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
   TAccountSource extends string | IAccountMeta<string> = string,
@@ -82,7 +88,7 @@ export function getTransferCheckedInstructionDataEncoder(): Encoder<TransferChec
       ['amount', getU64Encoder()],
       ['decimals', getU8Encoder()],
     ]),
-    (value) => ({ ...value, discriminator: 12 })
+    (value) => ({ ...value, discriminator: TRANSFER_CHECKED_DISCRIMINATOR })
   );
 }
 
@@ -128,15 +134,17 @@ export function getTransferCheckedInstruction<
   TAccountMint extends string,
   TAccountDestination extends string,
   TAccountAuthority extends string,
+  TProgramAddress extends Address = typeof TOKEN_PROGRAM_ADDRESS,
 >(
   input: TransferCheckedInput<
     TAccountSource,
     TAccountMint,
     TAccountDestination,
     TAccountAuthority
-  >
+  >,
+  config?: { programAddress?: TProgramAddress }
 ): TransferCheckedInstruction<
-  typeof TOKEN_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountSource,
   TAccountMint,
   TAccountDestination,
@@ -146,7 +154,7 @@ export function getTransferCheckedInstruction<
     : TAccountAuthority
 > {
   // Program address.
-  const programAddress = TOKEN_PROGRAM_ADDRESS;
+  const programAddress = config?.programAddress ?? TOKEN_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -186,7 +194,7 @@ export function getTransferCheckedInstruction<
       args as TransferCheckedInstructionDataArgs
     ),
   } as TransferCheckedInstruction<
-    typeof TOKEN_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountSource,
     TAccountMint,
     TAccountDestination,

--- a/clients/js/src/generated/instructions/uiAmountToAmount.ts
+++ b/clients/js/src/generated/instructions/uiAmountToAmount.ts
@@ -28,6 +28,12 @@ import {
 import { TOKEN_PROGRAM_ADDRESS } from '../programs';
 import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
 
+export const UI_AMOUNT_TO_AMOUNT_DISCRIMINATOR = 24;
+
+export function getUiAmountToAmountDiscriminatorBytes() {
+  return getU8Encoder().encode(UI_AMOUNT_TO_AMOUNT_DISCRIMINATOR);
+}
+
 export type UiAmountToAmountInstruction<
   TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
   TAccountMint extends string | IAccountMeta<string> = string,
@@ -60,7 +66,7 @@ export function getUiAmountToAmountInstructionDataEncoder(): Encoder<UiAmountToA
       ['discriminator', getU8Encoder()],
       ['uiAmount', getUtf8Encoder()],
     ]),
-    (value) => ({ ...value, discriminator: 24 })
+    (value) => ({ ...value, discriminator: UI_AMOUNT_TO_AMOUNT_DISCRIMINATOR })
   );
 }
 
@@ -87,11 +93,15 @@ export type UiAmountToAmountInput<TAccountMint extends string = string> = {
   uiAmount: UiAmountToAmountInstructionDataArgs['uiAmount'];
 };
 
-export function getUiAmountToAmountInstruction<TAccountMint extends string>(
-  input: UiAmountToAmountInput<TAccountMint>
-): UiAmountToAmountInstruction<typeof TOKEN_PROGRAM_ADDRESS, TAccountMint> {
+export function getUiAmountToAmountInstruction<
+  TAccountMint extends string,
+  TProgramAddress extends Address = typeof TOKEN_PROGRAM_ADDRESS,
+>(
+  input: UiAmountToAmountInput<TAccountMint>,
+  config?: { programAddress?: TProgramAddress }
+): UiAmountToAmountInstruction<TProgramAddress, TAccountMint> {
   // Program address.
-  const programAddress = TOKEN_PROGRAM_ADDRESS;
+  const programAddress = config?.programAddress ?? TOKEN_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -112,7 +122,7 @@ export function getUiAmountToAmountInstruction<TAccountMint extends string>(
     data: getUiAmountToAmountInstructionDataEncoder().encode(
       args as UiAmountToAmountInstructionDataArgs
     ),
-  } as UiAmountToAmountInstruction<typeof TOKEN_PROGRAM_ADDRESS, TAccountMint>;
+  } as UiAmountToAmountInstruction<TProgramAddress, TAccountMint>;
 
   return instruction;
 }

--- a/package.json
+++ b/package.json
@@ -20,9 +20,9 @@
   },
   "devDependencies": {
     "@iarna/toml": "^2.2.5",
-    "@kinobi-so/renderers-js": "^0.21.2",
-    "@kinobi-so/renderers-rust": "^0.21.0",
-    "kinobi": "^0.21.0",
+    "@kinobi-so/renderers-js": "^0.21.9",
+    "@kinobi-so/renderers-rust": "^0.21.7",
+    "kinobi": "^0.21.5",
     "typescript": "^5.5.2",
     "zx": "^7.2.3"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,14 +12,14 @@ importers:
         specifier: ^2.2.5
         version: 2.2.5
       '@kinobi-so/renderers-js':
-        specifier: ^0.21.2
-        version: 0.21.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
+        specifier: ^0.21.9
+        version: 0.21.9(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
       '@kinobi-so/renderers-rust':
-        specifier: ^0.21.0
-        version: 0.21.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
+        specifier: ^0.21.7
+        version: 0.21.7(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
       kinobi:
-        specifier: ^0.21.0
-        version: 0.21.0
+        specifier: ^0.21.5
+        version: 0.21.5
       typescript:
         specifier: ^5.5.2
         version: 5.5.3
@@ -32,40 +32,40 @@ packages:
   '@iarna/toml@2.2.5':
     resolution: {integrity: sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==}
 
-  '@kinobi-so/errors@0.21.0':
-    resolution: {integrity: sha512-7dPK35L/Y01qzekhVHdKAu+lENmHhuwX39rIx3qNJpNPHKi1VCcorLuOJlfT2F9MPPUjv5pZliL5qQ5IsvtNMw==}
+  '@kinobi-so/errors@0.21.5':
+    resolution: {integrity: sha512-IqPMOe0qbmuBI8vux9HU+tvx+SaCVk32g5GnRvYxJh6OmpYOEuJRg02nT2XtYPeYWB2IFKJ1X2AnwTbEz9Vx8Q==}
     hasBin: true
 
-  '@kinobi-so/node-types@0.21.0':
-    resolution: {integrity: sha512-UmzjocmsLa1pZ/ExVklGRsWQZNoIvifKBuTEAcpdxlDhg6hmrMWoXwWvRrLI5o7v1WKvTucv7KuM+5GU9UhFDw==}
+  '@kinobi-so/node-types@0.21.5':
+    resolution: {integrity: sha512-OKpk08+nTsO25xSZBT+PXpjx2FOHfn7jr0CbnQZ+ulfRa+dr3eSf7zSn+0ipKjG+FFWUUGpizgSkgpTQMjAqLA==}
 
-  '@kinobi-so/nodes-from-anchor@0.20.9':
-    resolution: {integrity: sha512-xNlwvJek6Hbfi45Unocwq/lT3rFXhmpZcAZmQJMgdIH8E4iAya9ZQ89j4neRQ+C1KVrK9qFJh0SaJvt9xnJQXA==}
+  '@kinobi-so/nodes-from-anchor@0.21.3':
+    resolution: {integrity: sha512-mar3UeJNx61k77NhucqYIwUXZvC0b6mhLYFksQY0Wz+gCFTWLr8exxB7KmgSycT+XuFNOydpYnEOeMa5lUywBQ==}
 
-  '@kinobi-so/nodes@0.21.0':
-    resolution: {integrity: sha512-Z8STFjB3/f9LzK494l6qydkBMsFtnm96YreJjlAg9/DeKNtphimslSvFTF/9qHiGMfOQpOVhQqbWFXpt+PCZiQ==}
+  '@kinobi-so/nodes@0.21.5':
+    resolution: {integrity: sha512-6iu9/GXrVs14olVeUAAw73BK2js7RGefVGHBDF6PKcvw6i0DlxhPkZiNOSpzweaeTmZsowHO7xEJKov0446fbQ==}
 
-  '@kinobi-so/renderers-core@0.20.7':
-    resolution: {integrity: sha512-KJhU8+UMowO9dDkLhEodAkbRkgSxdfBWeY+DIgOCgXcakt0T140K7OREuaAo9fp12Owf+10SAEGx9AzTNySoHA==}
+  '@kinobi-so/renderers-core@0.21.3':
+    resolution: {integrity: sha512-Ow1x0IaRmUlqQUAFTQZpq56wpkB6YKdnpNmfjM8IS/ssgz2IG5Jw3LREvNLvdXwpp/eyjSYOsux2RDFJkERl0g==}
 
-  '@kinobi-so/renderers-js@0.21.2':
-    resolution: {integrity: sha512-G576GAQ10ugmA63EZRlEbv892th37q9ow+AMzZD1vtypRCEJ7znakzySSDG3aeqaZujk2igKXFQTD+FHuY/xPg==}
+  '@kinobi-so/renderers-js@0.21.9':
+    resolution: {integrity: sha512-ZwN3UIYGZHu1V9TYsCPolVPdScR71r4PrLVVLsxixIxPBhdTMIgUbXK4OqHkzxaR5kn8Ssrvuq6+V2f7XFbVSg==}
 
-  '@kinobi-so/renderers-rust@0.21.0':
-    resolution: {integrity: sha512-BLe1SW6XFBhjtZdCc7cuukMWrJTbhCafCCmXryLmjzF7jaiK9nyZZFinHxljSac4HCk2vDn22mHAwOjabaDQ2Q==}
+  '@kinobi-so/renderers-rust@0.21.7':
+    resolution: {integrity: sha512-SXiUG1C/qL21F3bIeDzFmgLDtVXA53+2BDFaVEOx1tE7W7kcd4TkQGYvNw8o7EHNaa2S9paQB9KjQFyV+DsmqQ==}
 
-  '@kinobi-so/validators@0.21.0':
-    resolution: {integrity: sha512-mpBqgqlto/Wdj6rlf1mqWkyw00rPJw98bkNItXq+ofCEtBsjaMq9lsevCE+IPmfJJYEPFGHGJW4Gb6m/cLmOqw==}
+  '@kinobi-so/validators@0.21.5':
+    resolution: {integrity: sha512-JYZWHgma1TrnjhiUJn5/oYS9XfeirUBhwpuTPDRmRrSiHHv329gjWimzZO2uLAm5S5PgFyhLTz+S6jjxRsdNXg==}
 
-  '@kinobi-so/visitors-core@0.21.0':
-    resolution: {integrity: sha512-m6C/cAy7q7ZAWhByQGo2YnBsbt0qS3Un0lyT4mmPGQt0QFXUDExFipjTvY/NnzZ5lQJ2grvnL04pqLx8V7eiuw==}
+  '@kinobi-so/visitors-core@0.21.5':
+    resolution: {integrity: sha512-qNq9CcDh1P/A0BRR7zEdRpzeWL6ObAowMNWpkxZTT2BKqejK9oKWSh2/gzg6ehcn2Fn/J5DE8bnKZfAlEww95g==}
 
-  '@kinobi-so/visitors@0.21.0':
-    resolution: {integrity: sha512-gigysLJCfVtNCFkdDMeHGB+1SOvoiQOPUVKxewzOq1wDYVioFmmf4aXfB1GCEslLlMvl63cTJrwvh8bDIZoaSA==}
+  '@kinobi-so/visitors@0.21.5':
+    resolution: {integrity: sha512-RCJFaN1Q1f/MQW6PP3Oz0fgNXFVmfUEyErMzPM9CjBi1j2BJzTjff7IzEjbTpG7SbDY91eEyTDcl430ygcDBkA==}
 
-  '@noble/hashes@1.4.0':
-    resolution: {integrity: sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==}
-    engines: {node: '>= 16'}
+  '@noble/hashes@1.5.0':
+    resolution: {integrity: sha512-1j6kQFb7QRru7eKN3ZDvRcP13rugwdxZqCjbiAVZfIJwgj2A65UmT4TgARXGlXgnRkORLTDTrO19ZErt7+QXgA==}
+    engines: {node: ^14.21.3 || >=16}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -79,24 +79,24 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@solana/codecs-core@2.0.0-preview.4':
-    resolution: {integrity: sha512-A0VVuDDA5kNKZUinOqHxJQK32aKTucaVbvn31YenGzHX1gPqq+SOnFwgaEY6pq4XEopSmaK16w938ZQS8IvCnw==}
+  '@solana/codecs-core@2.0.0-rc.1':
+    resolution: {integrity: sha512-bauxqMfSs8EHD0JKESaNmNuNvkvHSuN3bbWAF5RjOfDu2PugxHrvRebmYauvSumZ3cTfQ4HJJX6PG5rN852qyQ==}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/codecs-numbers@2.0.0-preview.4':
-    resolution: {integrity: sha512-Q061rLtMadsO7uxpguT+Z7G4UHnjQ6moVIxAQxR58nLxDPCC7MB1Pk106/Z7NDhDLHTcd18uO6DZ7ajHZEn2XQ==}
+  '@solana/codecs-numbers@2.0.0-rc.1':
+    resolution: {integrity: sha512-J5i5mOkvukXn8E3Z7sGIPxsThRCgSdgTWJDQeZvucQ9PT6Y3HiVXJ0pcWiOWAoQ3RX8e/f4I3IC+wE6pZiJzDQ==}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/codecs-strings@2.0.0-preview.4':
-    resolution: {integrity: sha512-YDbsQePRWm+xnrfS64losSGRg8Wb76cjK1K6qfR8LPmdwIC3787x9uW5/E4icl/k+9nwgbIRXZ65lpF+ucZUnw==}
+  '@solana/codecs-strings@2.0.0-rc.1':
+    resolution: {integrity: sha512-9/wPhw8TbGRTt6mHC4Zz1RqOnuPTqq1Nb4EyuvpZ39GW6O2t2Q7Q0XxiB3+BdoEjwA2XgPw6e2iRfvYgqty44g==}
     peerDependencies:
       fastestsmallesttextencoderdecoder: ^1.0.22
       typescript: '>=5'
 
-  '@solana/errors@2.0.0-preview.4':
-    resolution: {integrity: sha512-kadtlbRv2LCWr8A9V22On15Us7Nn8BvqNaOB4hXsTB3O0fU40D1ru2l+cReqLcRPij4znqlRzW9Xi0m6J5DIhA==}
+  '@solana/errors@2.0.0-rc.1':
+    resolution: {integrity: sha512-ejNvQ2oJ7+bcFAYWj225lyRkHnixuAeb7RQCixm+5mH4n1IA4Qya/9Bmfy5RAAHQzxK43clu3kZmL5eF9VGtYQ==}
     hasBin: true
     peerDependencies:
       typescript: '>=5'
@@ -136,10 +136,6 @@ packages:
   chalk@5.3.0:
     resolution: {integrity: sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
-
-  commander@12.0.0:
-    resolution: {integrity: sha512-MwVNWlYjDTtOjX5PiD7o5pK0UrFU/OYgcJfjjK4RaHZETNtjJqrZa9Y9ds88+A+f+d5lv+561eZ+yCKoS3gbAA==}
-    engines: {node: '>=18'}
 
   commander@12.1.0:
     resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
@@ -276,8 +272,8 @@ packages:
   jsonify@0.0.1:
     resolution: {integrity: sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==}
 
-  kinobi@0.21.0:
-    resolution: {integrity: sha512-T71VNh4yS8uSvtNp1FEWhJGygW5/8O82SAlFRlPYsWiwqWH9X3eZwwUthBVH7dfazqs8GLia0rAMEmUP99iwLw==}
+  kinobi@0.21.5:
+    resolution: {integrity: sha512-1xgN00od8x4tokR1Xuqv5Gbg0Iqo9bzrEvA9o2rm63vXqoW7/C+TN1voPhj1SQE4h2VmpfM3MD1clTUvJK0J2g==}
 
   map-stream@0.1.0:
     resolution: {integrity: sha512-CkYQrPYZfWnu/DAmVCpTSX/xHpKZ80eKh2lAkyA6AJTef6bW+6JpbQZN5rofum7da+SyN1bi5ctTm+lTfcCW3g==}
@@ -406,40 +402,40 @@ snapshots:
 
   '@iarna/toml@2.2.5': {}
 
-  '@kinobi-so/errors@0.21.0':
+  '@kinobi-so/errors@0.21.5':
     dependencies:
-      '@kinobi-so/node-types': 0.21.0
+      '@kinobi-so/node-types': 0.21.5
       chalk: 5.3.0
-      commander: 12.0.0
+      commander: 12.1.0
 
-  '@kinobi-so/node-types@0.21.0': {}
+  '@kinobi-so/node-types@0.21.5': {}
 
-  '@kinobi-so/nodes-from-anchor@0.20.9':
+  '@kinobi-so/nodes-from-anchor@0.21.3':
     dependencies:
-      '@kinobi-so/errors': 0.21.0
-      '@kinobi-so/nodes': 0.21.0
-      '@kinobi-so/visitors': 0.21.0
-      '@noble/hashes': 1.4.0
+      '@kinobi-so/errors': 0.21.5
+      '@kinobi-so/nodes': 0.21.5
+      '@kinobi-so/visitors': 0.21.5
+      '@noble/hashes': 1.5.0
 
-  '@kinobi-so/nodes@0.21.0':
+  '@kinobi-so/nodes@0.21.5':
     dependencies:
-      '@kinobi-so/errors': 0.21.0
-      '@kinobi-so/node-types': 0.21.0
+      '@kinobi-so/errors': 0.21.5
+      '@kinobi-so/node-types': 0.21.5
 
-  '@kinobi-so/renderers-core@0.20.7':
+  '@kinobi-so/renderers-core@0.21.3':
     dependencies:
-      '@kinobi-so/errors': 0.21.0
-      '@kinobi-so/nodes': 0.21.0
-      '@kinobi-so/visitors-core': 0.21.0
+      '@kinobi-so/errors': 0.21.5
+      '@kinobi-so/nodes': 0.21.5
+      '@kinobi-so/visitors-core': 0.21.5
 
-  '@kinobi-so/renderers-js@0.21.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)':
+  '@kinobi-so/renderers-js@0.21.9(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)':
     dependencies:
-      '@kinobi-so/errors': 0.21.0
-      '@kinobi-so/nodes': 0.21.0
-      '@kinobi-so/nodes-from-anchor': 0.20.9
-      '@kinobi-so/renderers-core': 0.20.7
-      '@kinobi-so/visitors-core': 0.21.0
-      '@solana/codecs-strings': 2.0.0-preview.4(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
+      '@kinobi-so/errors': 0.21.5
+      '@kinobi-so/nodes': 0.21.5
+      '@kinobi-so/nodes-from-anchor': 0.21.3
+      '@kinobi-so/renderers-core': 0.21.3
+      '@kinobi-so/visitors-core': 0.21.5
+      '@solana/codecs-strings': 2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
       nunjucks: 3.2.4
       prettier: 3.3.3
     transitivePeerDependencies:
@@ -447,38 +443,38 @@ snapshots:
       - fastestsmallesttextencoderdecoder
       - typescript
 
-  '@kinobi-so/renderers-rust@0.21.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)':
+  '@kinobi-so/renderers-rust@0.21.7(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)':
     dependencies:
-      '@kinobi-so/errors': 0.21.0
-      '@kinobi-so/nodes': 0.21.0
-      '@kinobi-so/renderers-core': 0.20.7
-      '@kinobi-so/visitors-core': 0.21.0
-      '@solana/codecs-strings': 2.0.0-preview.4(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
+      '@kinobi-so/errors': 0.21.5
+      '@kinobi-so/nodes': 0.21.5
+      '@kinobi-so/renderers-core': 0.21.3
+      '@kinobi-so/visitors-core': 0.21.5
+      '@solana/codecs-strings': 2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
       nunjucks: 3.2.4
     transitivePeerDependencies:
       - chokidar
       - fastestsmallesttextencoderdecoder
       - typescript
 
-  '@kinobi-so/validators@0.21.0':
+  '@kinobi-so/validators@0.21.5':
     dependencies:
-      '@kinobi-so/errors': 0.21.0
-      '@kinobi-so/nodes': 0.21.0
-      '@kinobi-so/visitors-core': 0.21.0
+      '@kinobi-so/errors': 0.21.5
+      '@kinobi-so/nodes': 0.21.5
+      '@kinobi-so/visitors-core': 0.21.5
 
-  '@kinobi-so/visitors-core@0.21.0':
+  '@kinobi-so/visitors-core@0.21.5':
     dependencies:
-      '@kinobi-so/errors': 0.21.0
-      '@kinobi-so/nodes': 0.21.0
+      '@kinobi-so/errors': 0.21.5
+      '@kinobi-so/nodes': 0.21.5
       json-stable-stringify: 1.1.1
 
-  '@kinobi-so/visitors@0.21.0':
+  '@kinobi-so/visitors@0.21.5':
     dependencies:
-      '@kinobi-so/errors': 0.21.0
-      '@kinobi-so/nodes': 0.21.0
-      '@kinobi-so/visitors-core': 0.21.0
+      '@kinobi-so/errors': 0.21.5
+      '@kinobi-so/nodes': 0.21.5
+      '@kinobi-so/visitors-core': 0.21.5
 
-  '@noble/hashes@1.4.0': {}
+  '@noble/hashes@1.5.0': {}
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -492,26 +488,26 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.17.1
 
-  '@solana/codecs-core@2.0.0-preview.4(typescript@5.5.3)':
+  '@solana/codecs-core@2.0.0-rc.1(typescript@5.5.3)':
     dependencies:
-      '@solana/errors': 2.0.0-preview.4(typescript@5.5.3)
+      '@solana/errors': 2.0.0-rc.1(typescript@5.5.3)
       typescript: 5.5.3
 
-  '@solana/codecs-numbers@2.0.0-preview.4(typescript@5.5.3)':
+  '@solana/codecs-numbers@2.0.0-rc.1(typescript@5.5.3)':
     dependencies:
-      '@solana/codecs-core': 2.0.0-preview.4(typescript@5.5.3)
-      '@solana/errors': 2.0.0-preview.4(typescript@5.5.3)
+      '@solana/codecs-core': 2.0.0-rc.1(typescript@5.5.3)
+      '@solana/errors': 2.0.0-rc.1(typescript@5.5.3)
       typescript: 5.5.3
 
-  '@solana/codecs-strings@2.0.0-preview.4(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)':
+  '@solana/codecs-strings@2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)':
     dependencies:
-      '@solana/codecs-core': 2.0.0-preview.4(typescript@5.5.3)
-      '@solana/codecs-numbers': 2.0.0-preview.4(typescript@5.5.3)
-      '@solana/errors': 2.0.0-preview.4(typescript@5.5.3)
+      '@solana/codecs-core': 2.0.0-rc.1(typescript@5.5.3)
+      '@solana/codecs-numbers': 2.0.0-rc.1(typescript@5.5.3)
+      '@solana/errors': 2.0.0-rc.1(typescript@5.5.3)
       fastestsmallesttextencoderdecoder: 1.0.22
       typescript: 5.5.3
 
-  '@solana/errors@2.0.0-preview.4(typescript@5.5.3)':
+  '@solana/errors@2.0.0-rc.1(typescript@5.5.3)':
     dependencies:
       chalk: 5.3.0
       commander: 12.1.0
@@ -553,8 +549,6 @@ snapshots:
       set-function-length: 1.2.2
 
   chalk@5.3.0: {}
-
-  commander@12.0.0: {}
 
   commander@12.1.0: {}
 
@@ -696,12 +690,12 @@ snapshots:
 
   jsonify@0.0.1: {}
 
-  kinobi@0.21.0:
+  kinobi@0.21.5:
     dependencies:
-      '@kinobi-so/errors': 0.21.0
-      '@kinobi-so/nodes': 0.21.0
-      '@kinobi-so/validators': 0.21.0
-      '@kinobi-so/visitors': 0.21.0
+      '@kinobi-so/errors': 0.21.5
+      '@kinobi-so/nodes': 0.21.5
+      '@kinobi-so/validators': 0.21.5
+      '@kinobi-so/visitors': 0.21.5
 
   map-stream@0.1.0: {}
 


### PR DESCRIPTION
Bumping token client to pick up https://github.com/kinobi-so/kinobi/pull/224 

As renderers-js bumps from 0.21.2 to 0.21.9 there are some other changes in the generated js client here too 