### PR TITLE
p-token: Fix typo

### DIFF
--- a/p-token/src/processor/get_account_data_size.rs
+++ b/p-token/src/processor/get_account_data_size.rs
@@ -10,7 +10,7 @@ use super::check_account_owner;
 
 #[inline(always)]
 pub fn process_get_account_data_size(accounts: &[AccountInfo]) -> ProgramResult {
-    let [mint_info, _remaning @ ..] = accounts else {
+    let [mint_info, _remaining @ ..] = accounts else {
         return Err(ProgramError::NotEnoughAccountKeys);
     };
 

--- a/p-token/src/processor/revoke.rs
+++ b/p-token/src/processor/revoke.rs
@@ -8,7 +8,7 @@ use super::validate_owner;
 
 #[inline(always)]
 pub fn process_revoke(accounts: &[AccountInfo], _instruction_data: &[u8]) -> ProgramResult {
-    let [source_account_info, owner_info, remaning @ ..] = accounts else {
+    let [source_account_info, owner_info, remaining @ ..] = accounts else {
         return Err(ProgramError::NotEnoughAccountKeys);
     };
 
@@ -21,7 +21,7 @@ pub fn process_revoke(accounts: &[AccountInfo], _instruction_data: &[u8]) -> Pro
         return Err(TokenError::AccountFrozen.into());
     }
 
-    validate_owner(&source_account.owner, owner_info, remaning)?;
+    validate_owner(&source_account.owner, owner_info, remaining)?;
 
     source_account.clear_delegate();
     source_account.set_delegated_amount(0);

--- a/p-token/src/processor/set_authority.rs
+++ b/p-token/src/processor/set_authority.rs
@@ -22,7 +22,7 @@ pub fn process_set_authority(accounts: &[AccountInfo], instruction_data: &[u8]) 
 
     // Validates the accounts.
 
-    let [account_info, authority_info, remaning @ ..] = accounts else {
+    let [account_info, authority_info, remaining @ ..] = accounts else {
         return Err(ProgramError::NotEnoughAccountKeys);
     };
 
@@ -37,7 +37,7 @@ pub fn process_set_authority(accounts: &[AccountInfo], instruction_data: &[u8]) 
 
         match authority_type {
             AuthorityType::AccountOwner => {
-                validate_owner(&account.owner, authority_info, remaning)?;
+                validate_owner(&account.owner, authority_info, remaining)?;
 
                 if let Some(authority) = new_authority {
                     account.owner = *authority;
@@ -54,7 +54,7 @@ pub fn process_set_authority(accounts: &[AccountInfo], instruction_data: &[u8]) 
             }
             AuthorityType::CloseAccount => {
                 let authority = account.close_authority().unwrap_or(&account.owner);
-                validate_owner(authority, authority_info, remaning)?;
+                validate_owner(authority, authority_info, remaining)?;
 
                 if let Some(authority) = new_authority {
                     account.set_close_authority(authority);
@@ -77,7 +77,7 @@ pub fn process_set_authority(accounts: &[AccountInfo], instruction_data: &[u8]) 
                 // mint_authority.
                 let mint_authority = mint.mint_authority().ok_or(TokenError::FixedSupply)?;
 
-                validate_owner(mint_authority, authority_info, remaning)?;
+                validate_owner(mint_authority, authority_info, remaining)?;
 
                 if let Some(authority) = new_authority {
                     mint.set_mint_authority(authority);
@@ -92,7 +92,7 @@ pub fn process_set_authority(accounts: &[AccountInfo], instruction_data: &[u8]) 
                     .freeze_authority()
                     .ok_or(TokenError::MintCannotFreeze)?;
 
-                validate_owner(freeze_authority, authority_info, remaning)?;
+                validate_owner(freeze_authority, authority_info, remaining)?;
 
                 if let Some(authority) = new_authority {
                     mint.set_freeze_authority(authority);

--- a/p-token/src/processor/shared/approve.rs
+++ b/p-token/src/processor/shared/approve.rs
@@ -17,7 +17,7 @@ pub fn process_approve(
 
     let (source_account_info, expected_mint_info, delegate_info, owner_info, remaining) =
         if let Some(expected_decimals) = expected_decimals {
-            let [source_account_info, expected_mint_info, delegate_info, owner_info, remaning @ ..] =
+            let [source_account_info, expected_mint_info, delegate_info, owner_info, remaining @ ..] =
                 accounts
             else {
                 return Err(ProgramError::NotEnoughAccountKeys);
@@ -28,10 +28,10 @@ pub fn process_approve(
                 Some((expected_mint_info, expected_decimals)),
                 delegate_info,
                 owner_info,
-                remaning,
+                remaining,
             )
         } else {
-            let [source_account_info, delegate_info, owner_info, remaning @ ..] = accounts else {
+            let [source_account_info, delegate_info, owner_info, remaining @ ..] = accounts else {
                 return Err(ProgramError::NotEnoughAccountKeys);
             };
             (
@@ -39,7 +39,7 @@ pub fn process_approve(
                 None,
                 delegate_info,
                 owner_info,
-                remaning,
+                remaining,
             )
         };
 

--- a/p-token/src/processor/shared/initialize_account.rs
+++ b/p-token/src/processor/shared/initialize_account.rs
@@ -24,16 +24,16 @@ pub fn process_initialize_account(
 ) -> ProgramResult {
     // Accounts expected depend on whether we have the `rent_sysvar` account or not.
 
-    let (new_account_info, mint_info, owner, remaning) = if let Some(owner) = owner {
-        let [new_account_info, mint_info, remaning @ ..] = accounts else {
+    let (new_account_info, mint_info, owner, remaining) = if let Some(owner) = owner {
+        let [new_account_info, mint_info, remaining @ ..] = accounts else {
             return Err(ProgramError::NotEnoughAccountKeys);
         };
-        (new_account_info, mint_info, owner, remaning)
+        (new_account_info, mint_info, owner, remaining)
     } else {
-        let [new_account_info, mint_info, owner_info, remaning @ ..] = accounts else {
+        let [new_account_info, mint_info, owner_info, remaining @ ..] = accounts else {
             return Err(ProgramError::NotEnoughAccountKeys);
         };
-        (new_account_info, mint_info, owner_info.key(), remaning)
+        (new_account_info, mint_info, owner_info.key(), remaining)
     };
 
     // Check rent-exempt status of the token account.
@@ -41,7 +41,9 @@ pub fn process_initialize_account(
     let new_account_info_data_len = new_account_info.data_len();
 
     let minimum_balance = if rent_sysvar_account {
-        let rent_sysvar_info = remaning.first().ok_or(ProgramError::NotEnoughAccountKeys)?;
+        let rent_sysvar_info = remaining
+            .first()
+            .ok_or(ProgramError::NotEnoughAccountKeys)?;
         // SAFETY: single immutable borrow to `rent_sysvar_info`; account ID and length are
         // checked by `from_account_info_unchecked`.
         let rent = unsafe { Rent::from_account_info_unchecked(rent_sysvar_info)? };

--- a/p-token/src/processor/shared/transfer.rs
+++ b/p-token/src/processor/shared/transfer.rs
@@ -20,9 +20,9 @@ pub fn process_transfer(
         expected_mint_info,
         destination_account_info,
         authority_info,
-        remaning,
+        remaining,
     ) = if let Some(decimals) = expected_decimals {
-        let [source_account_info, mint_info, destination_account_info, authority_info, remaning @ ..] =
+        let [source_account_info, mint_info, destination_account_info, authority_info, remaining @ ..] =
             accounts
         else {
             return Err(ProgramError::NotEnoughAccountKeys);
@@ -32,10 +32,10 @@ pub fn process_transfer(
             Some((mint_info, decimals)),
             destination_account_info,
             authority_info,
-            remaning,
+            remaining,
         )
     } else {
-        let [source_account_info, destination_account_info, authority_info, remaning @ ..] =
+        let [source_account_info, destination_account_info, authority_info, remaining @ ..] =
             accounts
         else {
             return Err(ProgramError::NotEnoughAccountKeys);
@@ -45,7 +45,7 @@ pub fn process_transfer(
             None,
             destination_account_info,
             authority_info,
-            remaning,
+            remaining,
         )
     };
 
@@ -114,7 +114,7 @@ pub fn process_transfer(
     // Validates the authority (delegate or owner).
 
     if source_account.delegate() == Some(authority_info.key()) {
-        validate_owner(authority_info.key(), authority_info, remaning)?;
+        validate_owner(authority_info.key(), authority_info, remaining)?;
 
         let delegated_amount = source_account
             .delegated_amount()
@@ -129,7 +129,7 @@ pub fn process_transfer(
             }
         }
     } else {
-        validate_owner(&source_account.owner, authority_info, remaning)?;
+        validate_owner(&source_account.owner, authority_info, remaining)?;
     }
 
     if self_transfer || amount == 0 {


### PR DESCRIPTION
This PR fixes a typo on the processor implementation of `p-token` ("remaning" -> "remaining").