### PR TITLE
p-token: Add scripts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7135,28 +7135,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
-name = "token-interface"
-version = "0.0.0"
-dependencies = [
- "pinocchio",
- "pinocchio-pubkey",
-]
-
-[[package]]
-name = "token-program"
-version = "0.0.0"
-dependencies = [
- "assert_matches",
- "pinocchio",
- "pinocchio-log",
- "solana-program-test",
- "solana-sdk",
- "spl-token 4.0.2",
- "test-case",
- "token-interface",
-]
-
-[[package]]
 name = "tokio"
 version = "1.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7134,6 +7134,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
+name = "token-interface"
+version = "0.0.0"
+dependencies = [
+ "pinocchio",
+ "pinocchio-pubkey",
+]
+
+[[package]]
+name = "token-program"
+version = "0.0.0"
+dependencies = [
+ "assert_matches",
+ "pinocchio",
+ "pinocchio-log",
+ "solana-program-test",
+ "solana-sdk",
+ "spl-token 4.0.2",
+ "test-case",
+ "token-interface",
+]
+
+[[package]]
 name = "tokio"
 version = "1.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2674,6 +2674,7 @@ checksum = "8b22d5b84be05a8d6947c7cb71f7c849aa0f112acd4bf51c2a7c1c988ac0a9dc"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -7132,6 +7133,28 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "token-interface"
+version = "0.0.0"
+dependencies = [
+ "pinocchio",
+ "pinocchio-pubkey",
+]
+
+[[package]]
+name = "token-program"
+version = "0.0.0"
+dependencies = [
+ "assert_matches",
+ "pinocchio",
+ "pinocchio-log",
+ "solana-program-test",
+ "solana-sdk",
+ "spl-token 4.0.2",
+ "test-case",
+ "token-interface",
+]
 
 [[package]]
 name = "tokio"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7134,28 +7134,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
-name = "token-interface"
-version = "0.0.0"
-dependencies = [
- "pinocchio",
- "pinocchio-pubkey",
-]
-
-[[package]]
-name = "token-program"
-version = "0.0.0"
-dependencies = [
- "assert_matches",
- "pinocchio",
- "pinocchio-log",
- "solana-program-test",
- "solana-sdk",
- "spl-token 4.0.2",
- "test-case",
- "token-interface",
-]
-
-[[package]]
 name = "tokio"
 version = "1.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2674,7 +2674,6 @@ checksum = "8b22d5b84be05a8d6947c7cb71f7c849aa0f112acd4bf51c2a7c1c988ac0a9dc"
 dependencies = [
  "cc",
  "libc",
- "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/interface/README.md
+++ b/interface/README.md
@@ -22,4 +22,4 @@ This will add the `spl-token-interface` dependency to your `Cargo.toml` file.
 
 ## Documentation
 
-Read more about the SPL Token program on the crate [documentation](https://docs.rs/spl-token-interface).
+Read more about the SPL Token interface on the crate [documentation](https://docs.rs/spl-token-interface).

--- a/p-token/tests/amount_to_ui_amount.rs
+++ b/p-token/tests/amount_to_ui_amount.rs
@@ -9,7 +9,7 @@ use solana_sdk::{pubkey::Pubkey, signature::Signer, transaction::Transaction};
 #[test_case::test_case(TOKEN_PROGRAM_ID ; "p-token")]
 #[tokio::test]
 async fn amount_to_ui_amount(token_program: Pubkey) {
-    let mut context = ProgramTest::new("token_program", TOKEN_PROGRAM_ID, None)
+    let mut context = ProgramTest::new("pinocchio_token_program", TOKEN_PROGRAM_ID, None)
         .start_with_context()
         .await;
 

--- a/p-token/tests/approve.rs
+++ b/p-token/tests/approve.rs
@@ -14,7 +14,7 @@ use solana_sdk::{
 #[test_case::test_case(TOKEN_PROGRAM_ID ; "p-token")]
 #[tokio::test]
 async fn approve(token_program: Pubkey) {
-    let mut context = ProgramTest::new("token_program", TOKEN_PROGRAM_ID, None)
+    let mut context = ProgramTest::new("pinocchio_token_program", TOKEN_PROGRAM_ID, None)
         .start_with_context()
         .await;
 

--- a/p-token/tests/approve_checked.rs
+++ b/p-token/tests/approve_checked.rs
@@ -14,7 +14,7 @@ use solana_sdk::{
 #[test_case::test_case(TOKEN_PROGRAM_ID ; "p-token")]
 #[tokio::test]
 async fn approve_checked(token_program: Pubkey) {
-    let mut context = ProgramTest::new("token_program", TOKEN_PROGRAM_ID, None)
+    let mut context = ProgramTest::new("pinocchio_token_program", TOKEN_PROGRAM_ID, None)
         .start_with_context()
         .await;
 

--- a/p-token/tests/burn.rs
+++ b/p-token/tests/burn.rs
@@ -14,7 +14,7 @@ use solana_sdk::{
 #[test_case::test_case(TOKEN_PROGRAM_ID ; "p-token")]
 #[tokio::test]
 async fn burn(token_program: Pubkey) {
-    let mut context = ProgramTest::new("token_program", TOKEN_PROGRAM_ID, None)
+    let mut context = ProgramTest::new("pinocchio_token_program", TOKEN_PROGRAM_ID, None)
         .start_with_context()
         .await;
 

--- a/p-token/tests/burn_checked.rs
+++ b/p-token/tests/burn_checked.rs
@@ -14,7 +14,7 @@ use solana_sdk::{
 #[test_case::test_case(TOKEN_PROGRAM_ID ; "p-token")]
 #[tokio::test]
 async fn burn_checked(token_program: Pubkey) {
-    let mut context = ProgramTest::new("token_program", TOKEN_PROGRAM_ID, None)
+    let mut context = ProgramTest::new("pinocchio_token_program", TOKEN_PROGRAM_ID, None)
         .start_with_context()
         .await;
 

--- a/p-token/tests/close_account.rs
+++ b/p-token/tests/close_account.rs
@@ -13,7 +13,7 @@ use solana_sdk::{
 #[test_case::test_case(TOKEN_PROGRAM_ID ; "p-token")]
 #[tokio::test]
 async fn close_account(token_program: Pubkey) {
-    let mut context = ProgramTest::new("token_program", TOKEN_PROGRAM_ID, None)
+    let mut context = ProgramTest::new("pinocchio_token_program", TOKEN_PROGRAM_ID, None)
         .start_with_context()
         .await;
 

--- a/p-token/tests/freeze_account.rs
+++ b/p-token/tests/freeze_account.rs
@@ -15,7 +15,7 @@ use spl_token::state::AccountState;
 #[test_case::test_case(TOKEN_PROGRAM_ID ; "p-token")]
 #[tokio::test]
 async fn freeze_account(token_program: Pubkey) {
-    let mut context = ProgramTest::new("token_program", TOKEN_PROGRAM_ID, None)
+    let mut context = ProgramTest::new("pinocchio_token_program", TOKEN_PROGRAM_ID, None)
         .start_with_context()
         .await;
 

--- a/p-token/tests/initialize_account.rs
+++ b/p-token/tests/initialize_account.rs
@@ -15,7 +15,7 @@ use solana_sdk::{
 #[test_case::test_case(TOKEN_PROGRAM_ID ; "p-token")]
 #[tokio::test]
 async fn initialize_account(token_program: Pubkey) {
-    let mut context = ProgramTest::new("token_program", TOKEN_PROGRAM_ID, None)
+    let mut context = ProgramTest::new("pinocchio_token_program", TOKEN_PROGRAM_ID, None)
         .start_with_context()
         .await;
 

--- a/p-token/tests/initialize_account2.rs
+++ b/p-token/tests/initialize_account2.rs
@@ -15,7 +15,7 @@ use solana_sdk::{
 #[test_case::test_case(TOKEN_PROGRAM_ID ; "p-token")]
 #[tokio::test]
 async fn initialize_account2(token_program: Pubkey) {
-    let mut context = ProgramTest::new("token_program", TOKEN_PROGRAM_ID, None)
+    let mut context = ProgramTest::new("pinocchio_token_program", TOKEN_PROGRAM_ID, None)
         .start_with_context()
         .await;
 

--- a/p-token/tests/initialize_account3.rs
+++ b/p-token/tests/initialize_account3.rs
@@ -15,7 +15,7 @@ use solana_sdk::{
 #[test_case::test_case(TOKEN_PROGRAM_ID ; "p-token")]
 #[tokio::test]
 async fn initialize_account3(token_program: Pubkey) {
-    let mut context = ProgramTest::new("token_program", TOKEN_PROGRAM_ID, None)
+    let mut context = ProgramTest::new("pinocchio_token_program", TOKEN_PROGRAM_ID, None)
         .start_with_context()
         .await;
 

--- a/p-token/tests/initialize_mint.rs
+++ b/p-token/tests/initialize_mint.rs
@@ -19,7 +19,7 @@ use spl_token_interface::state::mint::Mint;
 #[test_case::test_case(TOKEN_PROGRAM_ID ; "p-token")]
 #[tokio::test]
 async fn initialize_mint(token_program: Pubkey) {
-    let mut context = ProgramTest::new("token_program", TOKEN_PROGRAM_ID, None)
+    let context = ProgramTest::new("token_program", TOKEN_PROGRAM_ID, None)
         .start_with_context()
         .await;
 

--- a/p-token/tests/initialize_mint.rs
+++ b/p-token/tests/initialize_mint.rs
@@ -19,7 +19,7 @@ use spl_token_interface::state::mint::Mint;
 #[test_case::test_case(TOKEN_PROGRAM_ID ; "p-token")]
 #[tokio::test]
 async fn initialize_mint(token_program: Pubkey) {
-    let context = ProgramTest::new("token_program", TOKEN_PROGRAM_ID, None)
+    let context = ProgramTest::new("pinocchio_token_program", TOKEN_PROGRAM_ID, None)
         .start_with_context()
         .await;
 

--- a/p-token/tests/initialize_mint2.rs
+++ b/p-token/tests/initialize_mint2.rs
@@ -19,7 +19,7 @@ use spl_token_interface::state::mint::Mint;
 #[test_case::test_case(TOKEN_PROGRAM_ID ; "p-token")]
 #[tokio::test]
 async fn initialize_mint2(token_program: Pubkey) {
-    let context = ProgramTest::new("token_program", TOKEN_PROGRAM_ID, None)
+    let context = ProgramTest::new("pinocchio_token_program", TOKEN_PROGRAM_ID, None)
         .start_with_context()
         .await;
 

--- a/p-token/tests/initialize_mint2.rs
+++ b/p-token/tests/initialize_mint2.rs
@@ -19,7 +19,7 @@ use spl_token_interface::state::mint::Mint;
 #[test_case::test_case(TOKEN_PROGRAM_ID ; "p-token")]
 #[tokio::test]
 async fn initialize_mint2(token_program: Pubkey) {
-    let mut context = ProgramTest::new("token_program", TOKEN_PROGRAM_ID, None)
+    let context = ProgramTest::new("token_program", TOKEN_PROGRAM_ID, None)
         .start_with_context()
         .await;
 

--- a/p-token/tests/initialize_multisig.rs
+++ b/p-token/tests/initialize_multisig.rs
@@ -16,7 +16,7 @@ use spl_token::state::Multisig;
 #[test_case::test_case(TOKEN_PROGRAM_ID ; "p-token")]
 #[tokio::test]
 async fn initialize_multisig(token_program: Pubkey) {
-    let context = ProgramTest::new("token_program", TOKEN_PROGRAM_ID, None)
+    let context = ProgramTest::new("pinocchio_token_program", TOKEN_PROGRAM_ID, None)
         .start_with_context()
         .await;
 

--- a/p-token/tests/initialize_multisig.rs
+++ b/p-token/tests/initialize_multisig.rs
@@ -16,7 +16,7 @@ use spl_token::state::Multisig;
 #[test_case::test_case(TOKEN_PROGRAM_ID ; "p-token")]
 #[tokio::test]
 async fn initialize_multisig(token_program: Pubkey) {
-    let mut context = ProgramTest::new("token_program", TOKEN_PROGRAM_ID, None)
+    let context = ProgramTest::new("token_program", TOKEN_PROGRAM_ID, None)
         .start_with_context()
         .await;
 

--- a/p-token/tests/initialize_multisig2.rs
+++ b/p-token/tests/initialize_multisig2.rs
@@ -16,7 +16,7 @@ use spl_token::state::Multisig;
 #[test_case::test_case(TOKEN_PROGRAM_ID ; "p-token")]
 #[tokio::test]
 async fn initialize_multisig2(token_program: Pubkey) {
-    let mut context = ProgramTest::new("token_program", TOKEN_PROGRAM_ID, None)
+    let context = ProgramTest::new("token_program", TOKEN_PROGRAM_ID, None)
         .start_with_context()
         .await;
 

--- a/p-token/tests/initialize_multisig2.rs
+++ b/p-token/tests/initialize_multisig2.rs
@@ -16,7 +16,7 @@ use spl_token::state::Multisig;
 #[test_case::test_case(TOKEN_PROGRAM_ID ; "p-token")]
 #[tokio::test]
 async fn initialize_multisig2(token_program: Pubkey) {
-    let context = ProgramTest::new("token_program", TOKEN_PROGRAM_ID, None)
+    let context = ProgramTest::new("pinocchio_token_program", TOKEN_PROGRAM_ID, None)
         .start_with_context()
         .await;
 

--- a/p-token/tests/mint_to.rs
+++ b/p-token/tests/mint_to.rs
@@ -14,7 +14,7 @@ use solana_sdk::{
 #[test_case::test_case(TOKEN_PROGRAM_ID ; "p-token")]
 #[tokio::test]
 async fn mint_to(token_program: Pubkey) {
-    let mut context = ProgramTest::new("token_program", TOKEN_PROGRAM_ID, None)
+    let mut context = ProgramTest::new("pinocchio_token_program", TOKEN_PROGRAM_ID, None)
         .start_with_context()
         .await;
 

--- a/p-token/tests/mint_to_checked.rs
+++ b/p-token/tests/mint_to_checked.rs
@@ -14,7 +14,7 @@ use solana_sdk::{
 #[test_case::test_case(TOKEN_PROGRAM_ID ; "p-token")]
 #[tokio::test]
 async fn mint_to_checked(token_program: Pubkey) {
-    let mut context = ProgramTest::new("token_program", TOKEN_PROGRAM_ID, None)
+    let mut context = ProgramTest::new("pinocchio_token_program", TOKEN_PROGRAM_ID, None)
         .start_with_context()
         .await;
 

--- a/p-token/tests/revoke.rs
+++ b/p-token/tests/revoke.rs
@@ -14,7 +14,7 @@ use solana_sdk::{
 #[test_case::test_case(TOKEN_PROGRAM_ID ; "p-token")]
 #[tokio::test]
 async fn revoke(token_program: Pubkey) {
-    let mut context = ProgramTest::new("token_program", TOKEN_PROGRAM_ID, None)
+    let mut context = ProgramTest::new("pinocchio_token_program", TOKEN_PROGRAM_ID, None)
         .start_with_context()
         .await;
 

--- a/p-token/tests/set_authority.rs
+++ b/p-token/tests/set_authority.rs
@@ -16,7 +16,7 @@ use spl_token::instruction::AuthorityType;
 #[test_case::test_case(TOKEN_PROGRAM_ID ; "p-token")]
 #[tokio::test]
 async fn set_authority(token_program: Pubkey) {
-    let mut context = ProgramTest::new("token_program", TOKEN_PROGRAM_ID, None)
+    let mut context = ProgramTest::new("pinocchio_token_program", TOKEN_PROGRAM_ID, None)
         .start_with_context()
         .await;
 

--- a/p-token/tests/thaw_account.rs
+++ b/p-token/tests/thaw_account.rs
@@ -15,7 +15,7 @@ use spl_token::state::AccountState;
 #[test_case::test_case(TOKEN_PROGRAM_ID ; "p-token")]
 #[tokio::test]
 async fn thaw_account(token_program: Pubkey) {
-    let mut context = ProgramTest::new("token_program", TOKEN_PROGRAM_ID, None)
+    let mut context = ProgramTest::new("pinocchio_token_program", TOKEN_PROGRAM_ID, None)
         .start_with_context()
         .await;
 

--- a/p-token/tests/transfer.rs
+++ b/p-token/tests/transfer.rs
@@ -14,7 +14,7 @@ use solana_sdk::{
 #[test_case::test_case(TOKEN_PROGRAM_ID ; "p-token")]
 #[tokio::test]
 async fn transfer(token_program: Pubkey) {
-    let mut context = ProgramTest::new("token_program", TOKEN_PROGRAM_ID, None)
+    let mut context = ProgramTest::new("pinocchio_token_program", TOKEN_PROGRAM_ID, None)
         .start_with_context()
         .await;
 

--- a/p-token/tests/transfer_checked.rs
+++ b/p-token/tests/transfer_checked.rs
@@ -14,7 +14,7 @@ use solana_sdk::{
 #[test_case::test_case(TOKEN_PROGRAM_ID ; "p-token")]
 #[tokio::test]
 async fn transfer_checked(token_program: Pubkey) {
-    let mut context = ProgramTest::new("token_program", TOKEN_PROGRAM_ID, None)
+    let mut context = ProgramTest::new("pinocchio_token_program", TOKEN_PROGRAM_ID, None)
         .start_with_context()
         .await;
 

--- a/p-token/tests/ui_amount_to_amount.rs
+++ b/p-token/tests/ui_amount_to_amount.rs
@@ -9,7 +9,7 @@ use solana_sdk::{pubkey::Pubkey, signature::Signer, transaction::Transaction};
 #[test_case::test_case(TOKEN_PROGRAM_ID ; "p-token")]
 #[tokio::test]
 async fn ui_amount_to_amount(token_program: Pubkey) {
-    let mut context = ProgramTest::new("token_program", TOKEN_PROGRAM_ID, None)
+    let mut context = ProgramTest::new("pinocchio_token_program", TOKEN_PROGRAM_ID, None)
         .start_with_context()
         .await;
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,9 @@
     "rust:spellcheck": "cargo spellcheck --code 1",
     "rust:audit": "zx ./scripts/rust/audit.mjs",
     "rust:publish": "zx ./scripts/rust/publish.mjs",
-    "rust:semver": "cargo semver-checks"
+    "rust:semver": "cargo semver-checks",
+    "p-token:build": "zx ./scripts/rust/build-sbf.mjs p-token",
+    "p-token:test": "zx ./scripts/rust/test-sbf.mjs p-token"
   },
   "devDependencies": {
     "@codama/renderers-js": "^1.2.7",


### PR DESCRIPTION
### Problem

Currently it is not possible to build and test `p-token` program using `pnpm` scripts.

### Solution

Add `p-token:build` and `p-token:test` to `package.json` to build and test the program.

Starting from a fresh clone:
```
pnpm install
```
to install `pnpm` dependencies. Then we can use:
```
pnpm p-token:build
```
to build `p-token` binary – it will be located at `./target/deploy/pinocchio_token_program.so`. You can also use:
```
pnpm p-token:test
```
to run `p-token` tests.