### PR TITLE
p-token: Add format and lint scripts

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,6 +61,44 @@ jobs:
       - name: Lint
         run: pnpm programs:lint
 
+  format_and_lint_interface:
+    name: Format & Lint Interface
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Environment
+        uses: ./.github/actions/setup
+        with:
+          clippy: true
+          rustfmt: true
+
+      - name: Format
+        run: pnpm interface:format
+
+      - name: Lint
+        run: pnpm interface:lint
+
+  format_and_lint_ptoken:
+    name: Format & Lint p-token
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Environment
+        uses: ./.github/actions/setup
+        with:
+          clippy: true
+          rustfmt: true
+
+      - name: Format
+        run: pnpm p-token:format
+
+      - name: Lint
+        run: pnpm p-token:lint
+              
   audit_rust:
     name: Audit Rust
     runs-on: ubuntu-latest
@@ -245,7 +283,7 @@ jobs:
   conformance_ptoken:
     name: Conformance Test for p-token
     runs-on: ubuntu-latest
-    needs: build_ptoken
+    needs: [format_and_lint_interface, format_and_lint_ptoken, build_ptoken]
     steps:
       - name: Git Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -192,6 +192,7 @@ jobs:
   build_ptoken:
     name: Build p-token
     runs-on: ubuntu-latest
+    needs: [format_and_lint_interface, format_and_lint_ptoken]
     steps:
       - name: Git Checkout
         uses: actions/checkout@v4
@@ -283,7 +284,7 @@ jobs:
   conformance_ptoken:
     name: Conformance Test for p-token
     runs-on: ubuntu-latest
-    needs: [format_and_lint_interface, format_and_lint_ptoken, build_ptoken]
+    needs: build_ptoken
     steps:
       - name: Git Checkout
         uses: actions/checkout@v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 level = "warn"
 check-cfg = [
     'cfg(target_os, values("solana"))',
-    'cfg(feature, values("frozen-abi", "no-entrypoint"))',
+    'cfg(feature, values("custom-alloc", "custom-panic", "frozen-abi", "no-entrypoint"))',
 ]
 
 [workspace.metadata.cli]

--- a/interface/src/instruction.rs
+++ b/interface/src/instruction.rs
@@ -65,11 +65,13 @@ pub enum TokenInstruction {
     ///
     ///   0. `[writable]` The multisignature account to initialize.
     ///   1. `[]` Rent sysvar.
-    ///   2. `..+N` `[signer]` The signer accounts, must equal to N where `1 <= N <= 11`.
+    ///   2. `..+N` `[signer]` The signer accounts, must equal to N where `1 <=
+    ///      N <= 11`.
     ///
     /// Data expected by this instruction:
     ///
-    ///   - `u8` The number of signers (M) required to validate this multisignature account.
+    ///   - `u8` The number of signers (M) required to validate this
+    ///     multisignature account.
     InitializeMultisig,
 
     /// Transfers tokens from one account to another either directly or via a
@@ -268,7 +270,8 @@ pub enum TokenInstruction {
     /// Data expected by this instruction:
     ///
     ///   - `u64` The amount of tokens to transfer.
-    ///   - `u8` Expected number of base 10 digits to the right of the decimal place.
+    ///   - `u8` Expected number of base 10 digits to the right of the decimal
+    ///     place.
     TransferChecked,
 
     /// Approves a delegate.  A delegate is given the authority over tokens on
@@ -296,7 +299,8 @@ pub enum TokenInstruction {
     /// Data expected by this instruction:
     ///
     ///   - `u64` The amount of tokens the delegate is approved for.
-    ///   - `u8` Expected number of base 10 digits to the right of the decimal place.
+    ///   - `u8` Expected number of base 10 digits to the right of the decimal
+    ///     place.
     ApproveChecked,
 
     /// Mints new tokens to an account.  The native mint does not support
@@ -322,7 +326,8 @@ pub enum TokenInstruction {
     /// Data expected by this instruction:
     ///
     ///   - `u64` The amount of new tokens to mint.
-    ///   - `u8` Expected number of base 10 digits to the right of the decimal place.
+    ///   - `u8` Expected number of base 10 digits to the right of the decimal
+    ///     place.
     MintToChecked,
 
     /// Burns tokens by removing them from an account.  [`BurnChecked`] does not
@@ -349,13 +354,14 @@ pub enum TokenInstruction {
     /// Data expected by this instruction:
     ///
     ///   - `u64` The amount of tokens to burn.
-    ///   - `u8` Expected number of base 10 digits to the right of the decimal place.
+    ///   - `u8` Expected number of base 10 digits to the right of the decimal
+    ///     place.
     BurnChecked,
 
-    /// Like [`InitializeAccount`], but the owner pubkey is passed via instruction
-    /// data rather than the accounts list. This variant may be preferable
-    /// when using Cross Program Invocation from an instruction that does
-    /// not need the owner's `AccountInfo` otherwise.
+    /// Like [`InitializeAccount`], but the owner pubkey is passed via
+    /// instruction data rather than the accounts list. This variant may be
+    /// preferable when using Cross Program Invocation from an instruction
+    /// that does not need the owner's `AccountInfo` otherwise.
     ///
     /// Accounts expected by this instruction:
     ///
@@ -399,11 +405,13 @@ pub enum TokenInstruction {
     /// Accounts expected by this instruction:
     ///
     ///   0. `[writable]` The multisignature account to initialize.
-    ///   1. `..+N` `[signer]` The signer accounts, must equal to N where `1 <= N <= 11`.
+    ///   1. `..+N` `[signer]` The signer accounts, must equal to N where `1 <=
+    ///      N <= 11`.
     ///
     /// Data expected by this instruction:
     ///
-    ///   - `u8` The number of signers (M) required to validate this multisignature account.
+    ///   - `u8` The number of signers (M) required to validate this
+    ///     multisignature account.
     InitializeMultisig2,
 
     /// Like [`InitializeMint`], but does not require the Rent sysvar to be
@@ -462,9 +470,9 @@ pub enum TokenInstruction {
     ///   - `u64` The amount of tokens to reformat.
     AmountToUiAmount,
 
-    /// Convert a `UiAmount` of tokens to a little-endian `u64` raw Amount, using
-    /// the given mint. In this version of the program, the mint can only
-    /// specify the number of decimals.
+    /// Convert a `UiAmount` of tokens to a little-endian `u64` raw Amount,
+    /// using the given mint. In this version of the program, the mint can
+    /// only specify the number of decimals.
     ///
     /// Return data can be fetched using `sol_get_return_data` and deserializing
     /// the return data as a little-endian `u64`.
@@ -490,22 +498,26 @@ pub enum TokenInstruction {
     ///   3. `..+M` `[signer]` M signer accounts.
     WithdrawExcessLamports = 38,
 
-    /// Executes a batch of instructions. The instructions to be executed are specified
-    /// in sequence on the instruction data. Each instruction provides:
+    /// Executes a batch of instructions. The instructions to be executed are
+    /// specified in sequence on the instruction data. Each instruction
+    /// provides:
     ///   - `u8`: number of accounts
     ///   - `u8`: instruction data length (includes the discriminator)
     ///   - `u8`: instruction discriminator
     ///   - `[u8]`: instruction data
     ///
-    /// Accounts follow a similar pattern, where accounts for each instruction are
-    /// specified in sequence. Therefore, the number of accounts expected by this
-    /// instruction is variable, i.e., it depends on the instructions provided.
+    /// Accounts follow a similar pattern, where accounts for each instruction
+    /// are specified in sequence. Therefore, the number of accounts
+    /// expected by this instruction is variable, i.e., it depends on the
+    /// instructions provided.
     ///
-    /// Both the number of accounts and instruction data length are used to identify
-    /// the slice of accounts and instruction data for each instruction.
+    /// Both the number of accounts and instruction data length are used to
+    /// identify the slice of accounts and instruction data for each
+    /// instruction.
     ///
-    /// Note that it is not sound to have a `batch` instruction that contains other
-    /// `batch` instruction; an error will be raised when this is detected.
+    /// Note that it is not sound to have a `batch` instruction that contains
+    /// other `batch` instruction; an error will be raised when this is
+    /// detected.
     Batch = 255,
     // Any new variants also need to be added to program-2022 `TokenInstruction`, so that the
     // latter remains a superset of this instruction set. New variants also need to be added to
@@ -554,8 +566,10 @@ impl TryFrom<u8> for AuthorityType {
 
 #[cfg(test)]
 mod tests {
-    use super::{AuthorityType, TokenInstruction};
-    use strum::IntoEnumIterator;
+    use {
+        super::{AuthorityType, TokenInstruction},
+        strum::IntoEnumIterator,
+    };
 
     #[test]
     fn test_token_instruction_from_u8_exhaustive() {

--- a/interface/src/state/account.rs
+++ b/interface/src/state/account.rs
@@ -1,6 +1,7 @@
-use pinocchio::pubkey::Pubkey;
-
-use super::{account_state::AccountState, COption, Initializable, Transmutable};
+use {
+    super::{account_state::AccountState, COption, Initializable, Transmutable},
+    pinocchio::pubkey::Pubkey,
+};
 
 /// Incinerator address.
 pub const INCINERATOR_ID: Pubkey =

--- a/interface/src/state/mint.rs
+++ b/interface/src/state/mint.rs
@@ -1,6 +1,7 @@
-use pinocchio::pubkey::Pubkey;
-
-use super::{COption, Initializable, Transmutable};
+use {
+    super::{COption, Initializable, Transmutable},
+    pinocchio::pubkey::Pubkey,
+};
 
 /// Internal representation of a mint data.
 #[repr(C)]

--- a/interface/src/state/mod.rs
+++ b/interface/src/state/mod.rs
@@ -10,8 +10,9 @@ pub type COption<T> = ([u8; 4], T);
 
 /// Marker trait for types that can be cast from a raw pointer.
 ///
-/// It is up to the type implementing this trait to guarantee that the cast is safe,
-/// i.e., the fields of the type are well aligned and there are no padding bytes.
+/// It is up to the type implementing this trait to guarantee that the cast is
+/// safe, i.e., the fields of the type are well aligned and there are no padding
+/// bytes.
 pub trait Transmutable {
     /// The length of the type.
     ///

--- a/interface/src/state/multisig.rs
+++ b/interface/src/state/multisig.rs
@@ -1,6 +1,7 @@
-use pinocchio::pubkey::Pubkey;
-
-use super::{Initializable, Transmutable};
+use {
+    super::{Initializable, Transmutable},
+    pinocchio::pubkey::Pubkey,
+};
 
 /// Minimum number of multisignature signers (min N)
 pub const MIN_SIGNERS: u8 = 1;
@@ -25,7 +26,8 @@ pub struct Multisig {
 }
 
 impl Multisig {
-    /// Utility function that checks index is between [`MIN_SIGNERS`] and [`MAX_SIGNERS`].
+    /// Utility function that checks index is between [`MIN_SIGNERS`] and
+    /// [`MAX_SIGNERS`].
     pub fn is_valid_signer_index(index: u8) -> bool {
         (MIN_SIGNERS..=MAX_SIGNERS).contains(&index)
     }

--- a/p-token/Cargo.toml
+++ b/p-token/Cargo.toml
@@ -27,3 +27,6 @@ solana-sdk = "2.1"
 spl-token = { version="^4", features=["no-entrypoint"] }
 spl-token-2022 = { version="^7", features=["no-entrypoint"] }
 test-case = "3.3.1"
+
+[lints]
+workspace = true

--- a/p-token/src/entrypoint.rs
+++ b/p-token/src/entrypoint.rs
@@ -1,9 +1,10 @@
-use pinocchio::{
-    account_info::AccountInfo, default_panic_handler, no_allocator, program_entrypoint,
-    program_error::ProgramError, pubkey::Pubkey, ProgramResult,
+use {
+    crate::processor::*,
+    pinocchio::{
+        account_info::AccountInfo, default_panic_handler, no_allocator, program_entrypoint,
+        program_error::ProgramError, pubkey::Pubkey, ProgramResult,
+    },
 };
-
-use crate::processor::*;
 
 program_entrypoint!(process_instruction);
 // Do not allocate memory.
@@ -13,10 +14,11 @@ default_panic_handler!();
 
 /// Process an instruction.
 ///
-/// In the first stage, the entrypoint checks the discriminator of the instruction data
-/// to determine whether the instruction is a "batch" instruction or a "regular" instruction.
-/// This avoids nesting of "batch" instructions, since it is not sound to have a "batch"
-/// instruction inside another "batch" instruction.
+/// In the first stage, the entrypoint checks the discriminator of the
+/// instruction data to determine whether the instruction is a "batch"
+/// instruction or a "regular" instruction. This avoids nesting of "batch"
+/// instructions, since it is not sound to have a "batch" instruction inside
+/// another "batch" instruction.
 #[inline(always)]
 pub fn process_instruction(
     _program_id: &Pubkey,
@@ -40,20 +42,21 @@ pub fn process_instruction(
 
 /// Process a "regular" instruction.
 ///
-/// The processor of the token program is divided into two parts to reduce the overhead
-/// of having a large `match` statement. The first part of the processor handles the
-/// most common instructions, while the second part handles the remaining instructions.
+/// The processor of the token program is divided into two parts to reduce the
+/// overhead of having a large `match` statement. The first part of the
+/// processor handles the most common instructions, while the second part
+/// handles the remaining instructions.
 ///
-/// The rationale is to reduce the overhead of making multiple comparisons for popular
-/// instructions.
+/// The rationale is to reduce the overhead of making multiple comparisons for
+/// popular instructions.
 ///
 /// Instructions on the first part of the inner processor:
 ///
-/// -  `0`: `InitializeMint`
-/// -  `1`: `InitializeAccount`
-/// -  `3`: `Transfer`
-/// -  `7`: `MintTo`
-/// -  `9`: `CloseAccount`
+/// - `0`: `InitializeMint`
+/// - `1`: `InitializeAccount`
+/// - `3`: `Transfer`
+/// - `7`: `MintTo`
+/// - `9`: `CloseAccount`
 /// - `16`: `InitializeAccount2`
 /// - `18`: `InitializeAccount3`
 /// - `20`: `InitializeMint2`
@@ -129,9 +132,10 @@ pub(crate) fn inner_process_instruction(
 
 /// Process a remaining "regular" instruction.
 ///
-/// This function is called by the [`inner_process_instruction`] function if the discriminator
-/// does not match any of the common instructions. This function is used to reduce the
-/// overhead of having a large `match` statement in the [`inner_process_instruction`] function.
+/// This function is called by the [`inner_process_instruction`] function if the
+/// discriminator does not match any of the common instructions. This function
+/// is used to reduce the overhead of having a large `match` statement in the
+/// [`inner_process_instruction`] function.
 fn inner_process_remaining_instruction(
     accounts: &[AccountInfo],
     instruction_data: &[u8],

--- a/p-token/src/processor/amount_to_ui_amount.rs
+++ b/p-token/src/processor/amount_to_ui_amount.rs
@@ -1,14 +1,16 @@
-use core::str::from_utf8_unchecked;
-use pinocchio::{
-    account_info::AccountInfo, program::set_return_data, program_error::ProgramError, ProgramResult,
+use {
+    super::{check_account_owner, MAX_FORMATTED_DIGITS},
+    core::str::from_utf8_unchecked,
+    pinocchio::{
+        account_info::AccountInfo, program::set_return_data, program_error::ProgramError,
+        ProgramResult,
+    },
+    pinocchio_log::logger::{Argument, Logger},
+    spl_token_interface::{
+        error::TokenError,
+        state::{load, mint::Mint},
+    },
 };
-use pinocchio_log::logger::{Argument, Logger};
-use spl_token_interface::{
-    error::TokenError,
-    state::{load, mint::Mint},
-};
-
-use super::{check_account_owner, MAX_FORMATTED_DIGITS};
 
 #[inline(always)]
 pub fn process_amount_to_ui_amount(

--- a/p-token/src/processor/approve.rs
+++ b/p-token/src/processor/approve.rs
@@ -1,6 +1,7 @@
-use pinocchio::{account_info::AccountInfo, program_error::ProgramError, ProgramResult};
-
-use super::shared;
+use {
+    super::shared,
+    pinocchio::{account_info::AccountInfo, program_error::ProgramError, ProgramResult},
+};
 
 #[inline(always)]
 pub fn process_approve(accounts: &[AccountInfo], instruction_data: &[u8]) -> ProgramResult {

--- a/p-token/src/processor/approve_checked.rs
+++ b/p-token/src/processor/approve_checked.rs
@@ -1,6 +1,7 @@
-use pinocchio::{account_info::AccountInfo, program_error::ProgramError, ProgramResult};
-
-use super::shared;
+use {
+    super::shared,
+    pinocchio::{account_info::AccountInfo, program_error::ProgramError, ProgramResult},
+};
 
 #[inline(always)]
 pub fn process_approve_checked(accounts: &[AccountInfo], instruction_data: &[u8]) -> ProgramResult {

--- a/p-token/src/processor/batch.rs
+++ b/p-token/src/processor/batch.rs
@@ -10,6 +10,7 @@ use {
 ///  * length of the instruction data
 const IX_HEADER_SIZE: usize = 2;
 
+#[allow(clippy::arithmetic_side_effects)]
 pub fn process_batch(mut accounts: &[AccountInfo], mut instruction_data: &[u8]) -> ProgramResult {
     loop {
         // Validates the instruction data and accounts offset.
@@ -20,8 +21,8 @@ pub fn process_batch(mut accounts: &[AccountInfo], mut instruction_data: &[u8]) 
         }
 
         // SAFETY: The instruction data is guaranteed to have at least two bytes
-        // (header)
-        // + one byte (discriminator).
+        // (header) + one byte (discriminator) and the values are within the bounds
+        // of an `usize`.
         let expected_accounts = unsafe { *instruction_data.get_unchecked(0) as usize };
         let data_offset = IX_HEADER_SIZE + unsafe { *instruction_data.get_unchecked(1) as usize };
 

--- a/p-token/src/processor/batch.rs
+++ b/p-token/src/processor/batch.rs
@@ -1,6 +1,7 @@
-use pinocchio::{account_info::AccountInfo, program_error::ProgramError, ProgramResult};
-
-use crate::entrypoint::inner_process_instruction;
+use {
+    crate::entrypoint::inner_process_instruction,
+    pinocchio::{account_info::AccountInfo, program_error::ProgramError, ProgramResult},
+};
 
 /// The size of the batch instruction header.
 ///
@@ -18,7 +19,8 @@ pub fn process_batch(mut accounts: &[AccountInfo], mut instruction_data: &[u8]) 
             return Err(ProgramError::InvalidInstructionData);
         }
 
-        // SAFETY: The instruction data is guaranteed to have at least two bytes (header)
+        // SAFETY: The instruction data is guaranteed to have at least two bytes
+        // (header)
         // + one byte (discriminator).
         let expected_accounts = unsafe { *instruction_data.get_unchecked(0) as usize };
         let data_offset = IX_HEADER_SIZE + unsafe { *instruction_data.get_unchecked(1) as usize };
@@ -33,8 +35,8 @@ pub fn process_batch(mut accounts: &[AccountInfo], mut instruction_data: &[u8]) 
 
         // Process the instruction.
 
-        // SAFETY: The instruction data and accounts lengths are already validated so all
-        // slices are guaranteed to be valid.
+        // SAFETY: The instruction data and accounts lengths are already validated so
+        // all slices are guaranteed to be valid.
         let (ix_accounts, ix_data) = unsafe {
             (
                 accounts.get_unchecked(..expected_accounts),

--- a/p-token/src/processor/burn.rs
+++ b/p-token/src/processor/burn.rs
@@ -1,6 +1,7 @@
-use pinocchio::{account_info::AccountInfo, program_error::ProgramError, ProgramResult};
-
-use super::shared;
+use {
+    super::shared,
+    pinocchio::{account_info::AccountInfo, program_error::ProgramError, ProgramResult},
+};
 
 #[inline(always)]
 pub fn process_burn(accounts: &[AccountInfo], instruction_data: &[u8]) -> ProgramResult {

--- a/p-token/src/processor/burn_checked.rs
+++ b/p-token/src/processor/burn_checked.rs
@@ -1,6 +1,7 @@
-use pinocchio::{account_info::AccountInfo, program_error::ProgramError, ProgramResult};
-
-use super::shared;
+use {
+    super::shared,
+    pinocchio::{account_info::AccountInfo, program_error::ProgramError, ProgramResult},
+};
 
 #[inline(always)]
 pub fn process_burn_checked(accounts: &[AccountInfo], instruction_data: &[u8]) -> ProgramResult {

--- a/p-token/src/processor/close_account.rs
+++ b/p-token/src/processor/close_account.rs
@@ -1,13 +1,14 @@
-use pinocchio::{account_info::AccountInfo, program_error::ProgramError, ProgramResult};
-use spl_token_interface::{
-    error::TokenError,
-    state::{
-        account::{Account, INCINERATOR_ID},
-        load,
+use {
+    super::validate_owner,
+    pinocchio::{account_info::AccountInfo, program_error::ProgramError, ProgramResult},
+    spl_token_interface::{
+        error::TokenError,
+        state::{
+            account::{Account, INCINERATOR_ID},
+            load,
+        },
     },
 };
-
-use super::validate_owner;
 
 #[inline(always)]
 pub fn process_close_account(accounts: &[AccountInfo]) -> ProgramResult {

--- a/p-token/src/processor/freeze_account.rs
+++ b/p-token/src/processor/freeze_account.rs
@@ -1,6 +1,7 @@
-use pinocchio::{account_info::AccountInfo, ProgramResult};
-
-use super::shared::toggle_account_state::process_toggle_account_state;
+use {
+    super::shared::toggle_account_state::process_toggle_account_state,
+    pinocchio::{account_info::AccountInfo, ProgramResult},
+};
 
 #[inline(always)]
 pub fn process_freeze_account(accounts: &[AccountInfo]) -> ProgramResult {

--- a/p-token/src/processor/get_account_data_size.rs
+++ b/p-token/src/processor/get_account_data_size.rs
@@ -1,12 +1,14 @@
-use pinocchio::{
-    account_info::AccountInfo, program::set_return_data, program_error::ProgramError, ProgramResult,
+use {
+    super::check_account_owner,
+    pinocchio::{
+        account_info::AccountInfo, program::set_return_data, program_error::ProgramError,
+        ProgramResult,
+    },
+    spl_token_interface::{
+        error::TokenError,
+        state::{account::Account, load, mint::Mint, Transmutable},
+    },
 };
-use spl_token_interface::{
-    error::TokenError,
-    state::{account::Account, load, mint::Mint, Transmutable},
-};
-
-use super::check_account_owner;
 
 #[inline(always)]
 pub fn process_get_account_data_size(accounts: &[AccountInfo]) -> ProgramResult {

--- a/p-token/src/processor/initialize_account.rs
+++ b/p-token/src/processor/initialize_account.rs
@@ -1,6 +1,7 @@
-use pinocchio::{account_info::AccountInfo, ProgramResult};
-
-use super::shared;
+use {
+    super::shared,
+    pinocchio::{account_info::AccountInfo, ProgramResult},
+};
 
 #[inline(always)]
 pub fn process_initialize_account(accounts: &[AccountInfo]) -> ProgramResult {

--- a/p-token/src/processor/initialize_account2.rs
+++ b/p-token/src/processor/initialize_account2.rs
@@ -1,8 +1,9 @@
-use pinocchio::{
-    account_info::AccountInfo, program_error::ProgramError, pubkey::Pubkey, ProgramResult,
+use {
+    super::shared,
+    pinocchio::{
+        account_info::AccountInfo, program_error::ProgramError, pubkey::Pubkey, ProgramResult,
+    },
 };
-
-use super::shared;
 
 #[inline(always)]
 pub fn process_initialize_account2(

--- a/p-token/src/processor/initialize_account3.rs
+++ b/p-token/src/processor/initialize_account3.rs
@@ -1,8 +1,9 @@
-use pinocchio::{
-    account_info::AccountInfo, program_error::ProgramError, pubkey::Pubkey, ProgramResult,
+use {
+    super::shared,
+    pinocchio::{
+        account_info::AccountInfo, program_error::ProgramError, pubkey::Pubkey, ProgramResult,
+    },
 };
-
-use super::shared;
 
 #[inline(always)]
 pub fn process_initialize_account3(

--- a/p-token/src/processor/initialize_immutable_owner.rs
+++ b/p-token/src/processor/initialize_immutable_owner.rs
@@ -1,7 +1,9 @@
-use pinocchio::{account_info::AccountInfo, program_error::ProgramError, ProgramResult};
-use spl_token_interface::{
-    error::TokenError,
-    state::{account::Account, load_unchecked, Initializable},
+use {
+    pinocchio::{account_info::AccountInfo, program_error::ProgramError, ProgramResult},
+    spl_token_interface::{
+        error::TokenError,
+        state::{account::Account, load_unchecked, Initializable},
+    },
 };
 
 #[inline(always)]

--- a/p-token/src/processor/initialize_mint.rs
+++ b/p-token/src/processor/initialize_mint.rs
@@ -1,6 +1,7 @@
-use pinocchio::{account_info::AccountInfo, ProgramResult};
-
-use super::shared;
+use {
+    super::shared,
+    pinocchio::{account_info::AccountInfo, ProgramResult},
+};
 
 #[inline(always)]
 pub fn process_initialize_mint(accounts: &[AccountInfo], instruction_data: &[u8]) -> ProgramResult {

--- a/p-token/src/processor/initialize_mint2.rs
+++ b/p-token/src/processor/initialize_mint2.rs
@@ -1,6 +1,7 @@
-use pinocchio::{account_info::AccountInfo, ProgramResult};
-
-use super::shared::initialize_mint::process_initialize_mint;
+use {
+    super::shared::initialize_mint::process_initialize_mint,
+    pinocchio::{account_info::AccountInfo, ProgramResult},
+};
 
 #[inline(always)]
 pub fn process_initialize_mint2(

--- a/p-token/src/processor/initialize_multisig.rs
+++ b/p-token/src/processor/initialize_multisig.rs
@@ -1,6 +1,7 @@
-use pinocchio::{account_info::AccountInfo, program_error::ProgramError, ProgramResult};
-
-use super::shared;
+use {
+    super::shared,
+    pinocchio::{account_info::AccountInfo, program_error::ProgramError, ProgramResult},
+};
 
 #[inline(always)]
 pub fn process_initialize_multisig(

--- a/p-token/src/processor/initialize_multisig2.rs
+++ b/p-token/src/processor/initialize_multisig2.rs
@@ -1,6 +1,7 @@
-use pinocchio::{account_info::AccountInfo, program_error::ProgramError, ProgramResult};
-
-use super::shared;
+use {
+    super::shared,
+    pinocchio::{account_info::AccountInfo, program_error::ProgramError, ProgramResult},
+};
 
 #[inline(always)]
 pub fn process_initialize_multisig2(

--- a/p-token/src/processor/mint_to.rs
+++ b/p-token/src/processor/mint_to.rs
@@ -1,6 +1,7 @@
-use pinocchio::{account_info::AccountInfo, program_error::ProgramError, ProgramResult};
-
-use super::shared;
+use {
+    super::shared,
+    pinocchio::{account_info::AccountInfo, program_error::ProgramError, ProgramResult},
+};
 
 #[inline(always)]
 pub fn process_mint_to(accounts: &[AccountInfo], instruction_data: &[u8]) -> ProgramResult {

--- a/p-token/src/processor/mint_to_checked.rs
+++ b/p-token/src/processor/mint_to_checked.rs
@@ -1,6 +1,7 @@
-use pinocchio::{account_info::AccountInfo, program_error::ProgramError, ProgramResult};
-
-use super::shared;
+use {
+    super::shared,
+    pinocchio::{account_info::AccountInfo, program_error::ProgramError, ProgramResult},
+};
 
 #[inline(always)]
 pub fn process_mint_to_checked(accounts: &[AccountInfo], instruction_data: &[u8]) -> ProgramResult {

--- a/p-token/src/processor/mod.rs
+++ b/p-token/src/processor/mod.rs
@@ -87,6 +87,7 @@ fn check_account_owner(account_info: &AccountInfo) -> ProgramResult {
 /// a multisig account, therefore it should not have any mutable borrows when
 /// calling this function.
 #[inline(always)]
+#[allow(clippy::arithmetic_side_effects)]
 fn validate_owner(
     expected_owner: &Pubkey,
     owner_account_info: &AccountInfo,
@@ -132,6 +133,7 @@ fn validate_owner(
 
 /// Try to convert a UI representation of a token amount to its raw amount using
 /// the given decimals field
+#[allow(clippy::arithmetic_side_effects)]
 fn try_ui_amount_into_amount(ui_amount: &str, decimals: u8) -> Result<u64, ProgramError> {
     let decimals = decimals as usize;
     let mut parts = ui_amount.split('.');

--- a/p-token/src/processor/mod.rs
+++ b/p-token/src/processor/mod.rs
@@ -1,15 +1,17 @@
-use core::{slice::from_raw_parts, str::from_utf8_unchecked};
-use pinocchio::{
-    account_info::AccountInfo, program_error::ProgramError, pubkey::Pubkey, syscalls::sol_memcpy_,
-    ProgramResult,
-};
-use spl_token_interface::{
-    error::TokenError,
-    program::ID as TOKEN_PROGRAM_ID,
-    state::{
-        load,
-        multisig::{Multisig, MAX_SIGNERS},
-        Transmutable,
+use {
+    core::{slice::from_raw_parts, str::from_utf8_unchecked},
+    pinocchio::{
+        account_info::AccountInfo, program_error::ProgramError, pubkey::Pubkey,
+        syscalls::sol_memcpy_, ProgramResult,
+    },
+    spl_token_interface::{
+        error::TokenError,
+        program::ID as TOKEN_PROGRAM_ID,
+        state::{
+            load,
+            multisig::{Multisig, MAX_SIGNERS},
+            Transmutable,
+        },
     },
 };
 
@@ -43,33 +45,24 @@ pub mod withdraw_excess_lamports;
 // Shared processors.
 pub mod shared;
 
-pub use amount_to_ui_amount::process_amount_to_ui_amount;
-pub use approve::process_approve;
-pub use approve_checked::process_approve_checked;
-pub use batch::process_batch;
-pub use burn::process_burn;
-pub use burn_checked::process_burn_checked;
-pub use close_account::process_close_account;
-pub use freeze_account::process_freeze_account;
-pub use get_account_data_size::process_get_account_data_size;
-pub use initialize_account::process_initialize_account;
-pub use initialize_account2::process_initialize_account2;
-pub use initialize_account3::process_initialize_account3;
-pub use initialize_immutable_owner::process_initialize_immutable_owner;
-pub use initialize_mint::process_initialize_mint;
-pub use initialize_mint2::process_initialize_mint2;
-pub use initialize_multisig::process_initialize_multisig;
-pub use initialize_multisig2::process_initialize_multisig2;
-pub use mint_to::process_mint_to;
-pub use mint_to_checked::process_mint_to_checked;
-pub use revoke::process_revoke;
-pub use set_authority::process_set_authority;
-pub use sync_native::process_sync_native;
-pub use thaw_account::process_thaw_account;
-pub use transfer::process_transfer;
-pub use transfer_checked::process_transfer_checked;
-pub use ui_amount_to_amount::process_ui_amount_to_amount;
-pub use withdraw_excess_lamports::process_withdraw_excess_lamports;
+pub use {
+    amount_to_ui_amount::process_amount_to_ui_amount, approve::process_approve,
+    approve_checked::process_approve_checked, batch::process_batch, burn::process_burn,
+    burn_checked::process_burn_checked, close_account::process_close_account,
+    freeze_account::process_freeze_account, get_account_data_size::process_get_account_data_size,
+    initialize_account::process_initialize_account,
+    initialize_account2::process_initialize_account2,
+    initialize_account3::process_initialize_account3,
+    initialize_immutable_owner::process_initialize_immutable_owner,
+    initialize_mint::process_initialize_mint, initialize_mint2::process_initialize_mint2,
+    initialize_multisig::process_initialize_multisig,
+    initialize_multisig2::process_initialize_multisig2, mint_to::process_mint_to,
+    mint_to_checked::process_mint_to_checked, revoke::process_revoke,
+    set_authority::process_set_authority, sync_native::process_sync_native,
+    thaw_account::process_thaw_account, transfer::process_transfer,
+    transfer_checked::process_transfer_checked, ui_amount_to_amount::process_ui_amount_to_amount,
+    withdraw_excess_lamports::process_withdraw_excess_lamports,
+};
 
 /// Maximum number of digits in a formatted `u64`.
 ///
@@ -106,10 +99,11 @@ fn validate_owner(
     if owner_account_info.data_len() == Multisig::LEN
         && owner_account_info.owner() == &TOKEN_PROGRAM_ID
     {
-        // SAFETY: the caller guarantees that there are no mutable borrows of `owner_account_info`
-        // account data and the `load` validates that the account is initialized; additionally,
-        // `Multisig` accounts are only ever loaded in this function, which means that previous
-        // loads will have already failed by the time we get here.
+        // SAFETY: the caller guarantees that there are no mutable borrows of
+        // `owner_account_info` account data and the `load` validates that the
+        // account is initialized; additionally, `Multisig` accounts are only
+        // ever loaded in this function, which means that previous loads will
+        // have already failed by the time we get here.
         let multisig = unsafe { load::<Multisig>(owner_account_info.borrow_data_unchecked())? };
 
         let mut num_signers = 0;

--- a/p-token/src/processor/revoke.rs
+++ b/p-token/src/processor/revoke.rs
@@ -1,10 +1,11 @@
-use pinocchio::{account_info::AccountInfo, program_error::ProgramError, ProgramResult};
-use spl_token_interface::{
-    error::TokenError,
-    state::{account::Account, load_mut},
+use {
+    super::validate_owner,
+    pinocchio::{account_info::AccountInfo, program_error::ProgramError, ProgramResult},
+    spl_token_interface::{
+        error::TokenError,
+        state::{account::Account, load_mut},
+    },
 };
-
-use super::validate_owner;
 
 #[inline(always)]
 pub fn process_revoke(accounts: &[AccountInfo], _instruction_data: &[u8]) -> ProgramResult {

--- a/p-token/src/processor/set_authority.rs
+++ b/p-token/src/processor/set_authority.rs
@@ -1,13 +1,14 @@
-use pinocchio::{
-    account_info::AccountInfo, program_error::ProgramError, pubkey::Pubkey, ProgramResult,
+use {
+    super::validate_owner,
+    pinocchio::{
+        account_info::AccountInfo, program_error::ProgramError, pubkey::Pubkey, ProgramResult,
+    },
+    spl_token_interface::{
+        error::TokenError,
+        instruction::AuthorityType,
+        state::{account::Account, load_mut, mint::Mint, Transmutable},
+    },
 };
-use spl_token_interface::{
-    error::TokenError,
-    instruction::AuthorityType,
-    state::{account::Account, load_mut, mint::Mint, Transmutable},
-};
-
-use super::validate_owner;
 
 #[inline(always)]
 pub fn process_set_authority(accounts: &[AccountInfo], instruction_data: &[u8]) -> ProgramResult {

--- a/p-token/src/processor/shared/approve.rs
+++ b/p-token/src/processor/shared/approve.rs
@@ -1,10 +1,11 @@
-use pinocchio::{account_info::AccountInfo, program_error::ProgramError, ProgramResult};
-use spl_token_interface::{
-    error::TokenError,
-    state::{account::Account, load, load_mut, mint::Mint},
+use {
+    crate::processor::validate_owner,
+    pinocchio::{account_info::AccountInfo, program_error::ProgramError, ProgramResult},
+    spl_token_interface::{
+        error::TokenError,
+        state::{account::Account, load, load_mut, mint::Mint},
+    },
 };
-
-use crate::processor::validate_owner;
 
 #[inline(always)]
 pub fn process_approve(
@@ -12,8 +13,8 @@ pub fn process_approve(
     amount: u64,
     expected_decimals: Option<u8>,
 ) -> ProgramResult {
-    // Accounts expected depend on whether we have the mint `decimals` or not; when we have the
-    // mint `decimals`, we expect the mint account to be present.
+    // Accounts expected depend on whether we have the mint `decimals` or not; when
+    // we have the mint `decimals`, we expect the mint account to be present.
 
     let (source_account_info, expected_mint_info, delegate_info, owner_info, remaining) =
         if let Some(expected_decimals) = expected_decimals {

--- a/p-token/src/processor/shared/burn.rs
+++ b/p-token/src/processor/shared/burn.rs
@@ -1,10 +1,11 @@
-use pinocchio::{account_info::AccountInfo, program_error::ProgramError, ProgramResult};
-use spl_token_interface::{
-    error::TokenError,
-    state::{account::Account, load_mut, mint::Mint},
+use {
+    crate::processor::{check_account_owner, validate_owner},
+    pinocchio::{account_info::AccountInfo, program_error::ProgramError, ProgramResult},
+    spl_token_interface::{
+        error::TokenError,
+        state::{account::Account, load_mut, mint::Mint},
+    },
 };
-
-use crate::processor::{check_account_owner, validate_owner};
 
 #[inline(always)]
 pub fn process_burn(

--- a/p-token/src/processor/shared/initialize_account.rs
+++ b/p-token/src/processor/shared/initialize_account.rs
@@ -18,6 +18,7 @@ use {
 };
 
 #[inline(always)]
+#[allow(clippy::arithmetic_side_effects)]
 pub fn process_initialize_account(
     accounts: &[AccountInfo],
     owner: Option<&Pubkey>,

--- a/p-token/src/processor/shared/initialize_account.rs
+++ b/p-token/src/processor/shared/initialize_account.rs
@@ -1,20 +1,21 @@
-use pinocchio::{
-    account_info::AccountInfo,
-    program_error::ProgramError,
-    pubkey::Pubkey,
-    sysvars::{rent::Rent, Sysvar},
-    ProgramResult,
-};
-use spl_token_interface::{
-    error::TokenError,
-    native_mint::is_native_mint,
-    state::{
-        account::Account, account_state::AccountState, load, load_mut_unchecked, mint::Mint,
-        Initializable,
+use {
+    crate::processor::check_account_owner,
+    pinocchio::{
+        account_info::AccountInfo,
+        program_error::ProgramError,
+        pubkey::Pubkey,
+        sysvars::{rent::Rent, Sysvar},
+        ProgramResult,
+    },
+    spl_token_interface::{
+        error::TokenError,
+        native_mint::is_native_mint,
+        state::{
+            account::Account, account_state::AccountState, load, load_mut_unchecked, mint::Mint,
+            Initializable,
+        },
     },
 };
-
-use crate::processor::check_account_owner;
 
 #[inline(always)]
 pub fn process_initialize_account(
@@ -44,8 +45,8 @@ pub fn process_initialize_account(
         let rent_sysvar_info = remaining
             .first()
             .ok_or(ProgramError::NotEnoughAccountKeys)?;
-        // SAFETY: single immutable borrow to `rent_sysvar_info`; account ID and length are
-        // checked by `from_account_info_unchecked`.
+        // SAFETY: single immutable borrow to `rent_sysvar_info`; account ID and length
+        // are checked by `from_account_info_unchecked`.
         let rent = unsafe { Rent::from_account_info_unchecked(rent_sysvar_info)? };
         rent.minimum_balance(new_account_info_data_len)
     } else {

--- a/p-token/src/processor/shared/initialize_mint.rs
+++ b/p-token/src/processor/shared/initialize_mint.rs
@@ -1,14 +1,16 @@
-use core::mem::size_of;
-use pinocchio::{
-    account_info::AccountInfo,
-    program_error::ProgramError,
-    pubkey::Pubkey,
-    sysvars::{rent::Rent, Sysvar},
-    ProgramResult,
-};
-use spl_token_interface::{
-    error::TokenError,
-    state::{load_mut_unchecked, mint::Mint, Initializable},
+use {
+    core::mem::size_of,
+    pinocchio::{
+        account_info::AccountInfo,
+        program_error::ProgramError,
+        pubkey::Pubkey,
+        sysvars::{rent::Rent, Sysvar},
+        ProgramResult,
+    },
+    spl_token_interface::{
+        error::TokenError,
+        state::{load_mut_unchecked, mint::Mint, Initializable},
+    },
 };
 
 #[inline(always)]
@@ -63,8 +65,8 @@ pub fn process_initialize_mint(
     // Check rent-exempt status of the mint account.
 
     let is_exempt = if let Some(rent_sysvar_info) = rent_sysvar_info {
-        // SAFETY: single immutable borrow to `rent_sysvar_info`; account ID and length are
-        // checked by `from_account_info_unchecked`.
+        // SAFETY: single immutable borrow to `rent_sysvar_info`; account ID and length
+        // are checked by `from_account_info_unchecked`.
         let rent = unsafe { Rent::from_account_info_unchecked(rent_sysvar_info)? };
         rent.is_exempt(mint_info.lamports(), size_of::<Mint>())
     } else {

--- a/p-token/src/processor/shared/initialize_multisig.rs
+++ b/p-token/src/processor/shared/initialize_multisig.rs
@@ -1,12 +1,14 @@
-use pinocchio::{
-    account_info::AccountInfo,
-    program_error::ProgramError,
-    sysvars::{rent::Rent, Sysvar},
-    ProgramResult,
-};
-use spl_token_interface::{
-    error::TokenError,
-    state::{load_mut_unchecked, multisig::Multisig, Initializable},
+use {
+    pinocchio::{
+        account_info::AccountInfo,
+        program_error::ProgramError,
+        sysvars::{rent::Rent, Sysvar},
+        ProgramResult,
+    },
+    spl_token_interface::{
+        error::TokenError,
+        state::{load_mut_unchecked, multisig::Multisig, Initializable},
+    },
 };
 
 #[inline(always)]
@@ -32,8 +34,8 @@ pub fn process_initialize_multisig(
     let multisig_info_data_len = multisig_info.data_len();
 
     let is_exempt = if let Some(rent_sysvar_info) = rent_sysvar_info {
-        // SAFETY: single immutable borrow to `rent_sysvar_info`; account ID and length are
-        // checked by `from_account_info_unchecked`.
+        // SAFETY: single immutable borrow to `rent_sysvar_info`; account ID and length
+        // are checked by `from_account_info_unchecked`.
         let rent = unsafe { Rent::from_account_info_unchecked(rent_sysvar_info)? };
         rent.is_exempt(multisig_info.lamports(), multisig_info_data_len)
     } else {

--- a/p-token/src/processor/shared/mint_to.rs
+++ b/p-token/src/processor/shared/mint_to.rs
@@ -1,10 +1,11 @@
-use pinocchio::{account_info::AccountInfo, program_error::ProgramError, ProgramResult};
-use spl_token_interface::{
-    error::TokenError,
-    state::{account::Account, load_mut, mint::Mint},
+use {
+    crate::processor::{check_account_owner, validate_owner},
+    pinocchio::{account_info::AccountInfo, program_error::ProgramError, ProgramResult},
+    spl_token_interface::{
+        error::TokenError,
+        state::{account::Account, load_mut, mint::Mint},
+    },
 };
-
-use crate::processor::{check_account_owner, validate_owner};
 
 #[inline(always)]
 pub fn process_mint_to(

--- a/p-token/src/processor/shared/mint_to.rs
+++ b/p-token/src/processor/shared/mint_to.rs
@@ -8,6 +8,7 @@ use {
 };
 
 #[inline(always)]
+#[allow(clippy::arithmetic_side_effects)]
 pub fn process_mint_to(
     accounts: &[AccountInfo],
     amount: u64,

--- a/p-token/src/processor/shared/toggle_account_state.rs
+++ b/p-token/src/processor/shared/toggle_account_state.rs
@@ -1,10 +1,11 @@
-use pinocchio::{account_info::AccountInfo, program_error::ProgramError, ProgramResult};
-use spl_token_interface::{
-    error::TokenError,
-    state::{account::Account, account_state::AccountState, load, load_mut, mint::Mint},
+use {
+    crate::processor::validate_owner,
+    pinocchio::{account_info::AccountInfo, program_error::ProgramError, ProgramResult},
+    spl_token_interface::{
+        error::TokenError,
+        state::{account::Account, account_state::AccountState, load, load_mut, mint::Mint},
+    },
 };
-
-use crate::processor::validate_owner;
 
 #[inline(always)]
 pub fn process_toggle_account_state(accounts: &[AccountInfo], freeze: bool) -> ProgramResult {

--- a/p-token/src/processor/shared/transfer.rs
+++ b/p-token/src/processor/shared/transfer.rs
@@ -8,6 +8,7 @@ use {
 };
 
 #[inline(always)]
+#[allow(clippy::arithmetic_side_effects)]
 pub fn process_transfer(
     accounts: &[AccountInfo],
     amount: u64,

--- a/p-token/src/processor/shared/transfer.rs
+++ b/p-token/src/processor/shared/transfer.rs
@@ -1,10 +1,11 @@
-use pinocchio::{account_info::AccountInfo, program_error::ProgramError, ProgramResult};
-use spl_token_interface::{
-    error::TokenError,
-    state::{account::Account, load, load_mut, load_mut_unchecked, mint::Mint},
+use {
+    crate::processor::{check_account_owner, validate_owner},
+    pinocchio::{account_info::AccountInfo, program_error::ProgramError, ProgramResult},
+    spl_token_interface::{
+        error::TokenError,
+        state::{account::Account, load, load_mut, load_mut_unchecked, mint::Mint},
+    },
 };
-
-use crate::processor::{check_account_owner, validate_owner};
 
 #[inline(always)]
 pub fn process_transfer(
@@ -12,8 +13,8 @@ pub fn process_transfer(
     amount: u64,
     expected_decimals: Option<u8>,
 ) -> ProgramResult {
-    // Accounts expected depend on whether we have the mint `decimals` or not; when we have the
-    // mint `decimals`, we expect the mint account to be present.
+    // Accounts expected depend on whether we have the mint `decimals` or not; when
+    // we have the mint `decimals`, we expect the mint account to be present.
 
     let (
         source_account_info,
@@ -68,8 +69,8 @@ pub fn process_transfer(
     // Note: the logic is partially duplicated for self transfers and transfers
     // to different accounts to improve CU consumption:
     //
-    //   - self-transfer: we only need to check that the source account is not frozen
-    //     and has enough tokens.
+    //   - self-transfer: we only need to check that the source account is not
+    //     frozen and has enough tokens.
     //
     //   - transfers to different accounts: we need to check that the source and
     //     destination accounts are not frozen, have the same mint, and the source
@@ -84,9 +85,9 @@ pub fn process_transfer(
             .checked_sub(amount)
             .ok_or(TokenError::InsufficientFunds)?
     } else {
-        // SAFETY: scoped immutable borrow to `destination_account_info` account data and
-        // `load` validates that the account is initialized; additionally, the account
-        // is guaranteed to be different than `source_account_info`.
+        // SAFETY: scoped immutable borrow to `destination_account_info` account data
+        // and `load` validates that the account is initialized; additionally,
+        // the account is guaranteed to be different than `source_account_info`.
         let destination_account =
             unsafe { load::<Account>(destination_account_info.borrow_data_unchecked())? };
 
@@ -153,9 +154,10 @@ pub fn process_transfer(
 
         source_account.set_amount(remaining_amount);
 
-        // SAFETY: single mutable borrow to `destination_account_info` account data; the account
-        // is guaranteed to be initialized and different than `source_account_info`; it was
-        // also already validated to be a token account.
+        // SAFETY: single mutable borrow to `destination_account_info` account data; the
+        // account is guaranteed to be initialized and different than
+        // `source_account_info`; it was also already validated to be a token
+        // account.
         let destination_account = unsafe {
             load_mut_unchecked::<Account>(destination_account_info.borrow_mut_data_unchecked())?
         };
@@ -170,8 +172,9 @@ pub fn process_transfer(
                 .checked_sub(amount)
                 .ok_or(TokenError::Overflow)?;
 
-            // SAFETY: single mutable borrow to `destination_account_info` lamports; the account
-            // is already validated to be different from `source_account_info`.
+            // SAFETY: single mutable borrow to `destination_account_info` lamports; the
+            // account is already validated to be different from
+            // `source_account_info`.
             let destination_lamports =
                 unsafe { destination_account_info.borrow_mut_lamports_unchecked() };
             *destination_lamports = destination_lamports

--- a/p-token/src/processor/sync_native.rs
+++ b/p-token/src/processor/sync_native.rs
@@ -1,10 +1,11 @@
-use pinocchio::{account_info::AccountInfo, program_error::ProgramError, ProgramResult};
-use spl_token_interface::{
-    error::TokenError,
-    state::{account::Account, load_mut},
+use {
+    super::check_account_owner,
+    pinocchio::{account_info::AccountInfo, program_error::ProgramError, ProgramResult},
+    spl_token_interface::{
+        error::TokenError,
+        state::{account::Account, load_mut},
+    },
 };
-
-use super::check_account_owner;
 
 #[inline(always)]
 pub fn process_sync_native(accounts: &[AccountInfo]) -> ProgramResult {

--- a/p-token/src/processor/thaw_account.rs
+++ b/p-token/src/processor/thaw_account.rs
@@ -1,6 +1,7 @@
-use pinocchio::{account_info::AccountInfo, ProgramResult};
-
-use super::shared::toggle_account_state::process_toggle_account_state;
+use {
+    super::shared::toggle_account_state::process_toggle_account_state,
+    pinocchio::{account_info::AccountInfo, ProgramResult},
+};
 
 #[inline(always)]
 pub fn process_thaw_account(accounts: &[AccountInfo]) -> ProgramResult {

--- a/p-token/src/processor/transfer.rs
+++ b/p-token/src/processor/transfer.rs
@@ -1,6 +1,7 @@
-use pinocchio::{account_info::AccountInfo, program_error::ProgramError, ProgramResult};
-
-use super::shared;
+use {
+    super::shared,
+    pinocchio::{account_info::AccountInfo, program_error::ProgramError, ProgramResult},
+};
 
 #[inline(always)]
 pub fn process_transfer(accounts: &[AccountInfo], instruction_data: &[u8]) -> ProgramResult {

--- a/p-token/src/processor/transfer_checked.rs
+++ b/p-token/src/processor/transfer_checked.rs
@@ -1,6 +1,7 @@
-use pinocchio::{account_info::AccountInfo, program_error::ProgramError, ProgramResult};
-
-use super::shared;
+use {
+    super::shared,
+    pinocchio::{account_info::AccountInfo, program_error::ProgramError, ProgramResult},
+};
 
 #[inline(always)]
 pub fn process_transfer_checked(

--- a/p-token/src/processor/ui_amount_to_amount.rs
+++ b/p-token/src/processor/ui_amount_to_amount.rs
@@ -1,13 +1,15 @@
-use core::str::from_utf8;
-use pinocchio::{
-    account_info::AccountInfo, program::set_return_data, program_error::ProgramError, ProgramResult,
+use {
+    super::{check_account_owner, try_ui_amount_into_amount},
+    core::str::from_utf8,
+    pinocchio::{
+        account_info::AccountInfo, program::set_return_data, program_error::ProgramError,
+        ProgramResult,
+    },
+    spl_token_interface::{
+        error::TokenError,
+        state::{load, mint::Mint},
+    },
 };
-use spl_token_interface::{
-    error::TokenError,
-    state::{load, mint::Mint},
-};
-
-use super::{check_account_owner, try_ui_amount_into_amount};
 
 #[inline(always)]
 pub fn process_ui_amount_to_amount(

--- a/p-token/src/processor/withdraw_excess_lamports.rs
+++ b/p-token/src/processor/withdraw_excess_lamports.rs
@@ -1,15 +1,16 @@
-use pinocchio::{
-    account_info::AccountInfo,
-    program_error::ProgramError,
-    sysvars::{rent::Rent, Sysvar},
-    ProgramResult,
+use {
+    super::validate_owner,
+    pinocchio::{
+        account_info::AccountInfo,
+        program_error::ProgramError,
+        sysvars::{rent::Rent, Sysvar},
+        ProgramResult,
+    },
+    spl_token_interface::{
+        error::TokenError,
+        state::{account::Account, load, mint::Mint, multisig::Multisig, Transmutable},
+    },
 };
-use spl_token_interface::{
-    error::TokenError,
-    state::{account::Account, load, mint::Mint, multisig::Multisig, Transmutable},
-};
-
-use super::validate_owner;
 
 #[inline(always)]
 pub fn process_withdraw_excess_lamports(accounts: &[AccountInfo]) -> ProgramResult {
@@ -61,8 +62,8 @@ pub fn process_withdraw_excess_lamports(accounts: &[AccountInfo]) -> ProgramResu
     unsafe {
         // Moves the lamports out of the source account.
         //
-        // Note: The `transfer_amount` is guaranteed to be less than the source account's
-        // lamports.
+        // Note: The `transfer_amount` is guaranteed to be less than the source
+        // account's lamports.
         *source_account_info.borrow_mut_lamports_unchecked() =
             source_starting_lamports - transfer_amount;
     }

--- a/p-token/src/processor/withdraw_excess_lamports.rs
+++ b/p-token/src/processor/withdraw_excess_lamports.rs
@@ -13,6 +13,7 @@ use {
 };
 
 #[inline(always)]
+#[allow(clippy::arithmetic_side_effects)]
 pub fn process_withdraw_excess_lamports(accounts: &[AccountInfo]) -> ProgramResult {
     let [source_account_info, destination_info, authority_info, remaining @ ..] = accounts else {
         return Err(ProgramError::NotEnoughAccountKeys);

--- a/p-token/tests/amount_to_ui_amount.rs
+++ b/p-token/tests/amount_to_ui_amount.rs
@@ -1,8 +1,10 @@
 mod setup;
 
-use setup::{mint, TOKEN_PROGRAM_ID};
-use solana_program_test::{tokio, ProgramTest};
-use solana_sdk::{pubkey::Pubkey, signature::Signer, transaction::Transaction};
+use {
+    setup::{mint, TOKEN_PROGRAM_ID},
+    solana_program_test::{tokio, ProgramTest},
+    solana_sdk::{pubkey::Pubkey, signature::Signer, transaction::Transaction},
+};
 
 #[test_case::test_case(TOKEN_PROGRAM_ID ; "p-token")]
 #[tokio::test]

--- a/p-token/tests/approve.rs
+++ b/p-token/tests/approve.rs
@@ -1,12 +1,14 @@
 mod setup;
 
-use setup::{account, mint, TOKEN_PROGRAM_ID};
-use solana_program_test::{tokio, ProgramTest};
-use solana_sdk::{
-    program_pack::Pack,
-    pubkey::Pubkey,
-    signature::{Keypair, Signer},
-    transaction::Transaction,
+use {
+    setup::{account, mint, TOKEN_PROGRAM_ID},
+    solana_program_test::{tokio, ProgramTest},
+    solana_sdk::{
+        program_pack::Pack,
+        pubkey::Pubkey,
+        signature::{Keypair, Signer},
+        transaction::Transaction,
+    },
 };
 
 #[test_case::test_case(TOKEN_PROGRAM_ID ; "p-token")]

--- a/p-token/tests/approve_checked.rs
+++ b/p-token/tests/approve_checked.rs
@@ -1,12 +1,14 @@
 mod setup;
 
-use setup::{account, mint, TOKEN_PROGRAM_ID};
-use solana_program_test::{tokio, ProgramTest};
-use solana_sdk::{
-    program_pack::Pack,
-    pubkey::Pubkey,
-    signature::{Keypair, Signer},
-    transaction::Transaction,
+use {
+    setup::{account, mint, TOKEN_PROGRAM_ID},
+    solana_program_test::{tokio, ProgramTest},
+    solana_sdk::{
+        program_pack::Pack,
+        pubkey::Pubkey,
+        signature::{Keypair, Signer},
+        transaction::Transaction,
+    },
 };
 
 #[test_case::test_case(TOKEN_PROGRAM_ID ; "p-token")]

--- a/p-token/tests/batch.rs
+++ b/p-token/tests/batch.rs
@@ -1,15 +1,17 @@
 mod setup;
 
-use crate::setup::TOKEN_PROGRAM_ID;
-use solana_program_test::{tokio, ProgramTest};
-use solana_sdk::{
-    instruction::{AccountMeta, Instruction},
-    program_error::ProgramError,
-    program_pack::Pack,
-    pubkey::Pubkey,
-    signature::{Keypair, Signer},
-    system_instruction,
-    transaction::Transaction,
+use {
+    crate::setup::TOKEN_PROGRAM_ID,
+    solana_program_test::{tokio, ProgramTest},
+    solana_sdk::{
+        instruction::{AccountMeta, Instruction},
+        program_error::ProgramError,
+        program_pack::Pack,
+        pubkey::Pubkey,
+        signature::{Keypair, Signer},
+        system_instruction,
+        transaction::Transaction,
+    },
 };
 
 fn batch_instruction(instructions: Vec<Instruction>) -> Result<Instruction, ProgramError> {

--- a/p-token/tests/burn.rs
+++ b/p-token/tests/burn.rs
@@ -1,12 +1,14 @@
 mod setup;
 
-use setup::{account, mint, TOKEN_PROGRAM_ID};
-use solana_program_test::{tokio, ProgramTest};
-use solana_sdk::{
-    program_pack::Pack,
-    pubkey::Pubkey,
-    signature::{Keypair, Signer},
-    transaction::Transaction,
+use {
+    setup::{account, mint, TOKEN_PROGRAM_ID},
+    solana_program_test::{tokio, ProgramTest},
+    solana_sdk::{
+        program_pack::Pack,
+        pubkey::Pubkey,
+        signature::{Keypair, Signer},
+        transaction::Transaction,
+    },
 };
 
 #[test_case::test_case(TOKEN_PROGRAM_ID ; "p-token")]

--- a/p-token/tests/burn_checked.rs
+++ b/p-token/tests/burn_checked.rs
@@ -1,12 +1,14 @@
 mod setup;
 
-use setup::{account, mint, TOKEN_PROGRAM_ID};
-use solana_program_test::{tokio, ProgramTest};
-use solana_sdk::{
-    program_pack::Pack,
-    pubkey::Pubkey,
-    signature::{Keypair, Signer},
-    transaction::Transaction,
+use {
+    setup::{account, mint, TOKEN_PROGRAM_ID},
+    solana_program_test::{tokio, ProgramTest},
+    solana_sdk::{
+        program_pack::Pack,
+        pubkey::Pubkey,
+        signature::{Keypair, Signer},
+        transaction::Transaction,
+    },
 };
 
 #[test_case::test_case(TOKEN_PROGRAM_ID ; "p-token")]

--- a/p-token/tests/close_account.rs
+++ b/p-token/tests/close_account.rs
@@ -1,11 +1,13 @@
 mod setup;
 
-use setup::{account, mint, TOKEN_PROGRAM_ID};
-use solana_program_test::{tokio, ProgramTest};
-use solana_sdk::{
-    pubkey::Pubkey,
-    signature::{Keypair, Signer},
-    transaction::Transaction,
+use {
+    setup::{account, mint, TOKEN_PROGRAM_ID},
+    solana_program_test::{tokio, ProgramTest},
+    solana_sdk::{
+        pubkey::Pubkey,
+        signature::{Keypair, Signer},
+        transaction::Transaction,
+    },
 };
 
 #[test_case::test_case(TOKEN_PROGRAM_ID ; "p-token")]

--- a/p-token/tests/freeze_account.rs
+++ b/p-token/tests/freeze_account.rs
@@ -1,14 +1,16 @@
 mod setup;
 
-use setup::{account, mint, TOKEN_PROGRAM_ID};
-use solana_program_test::{tokio, ProgramTest};
-use solana_sdk::{
-    program_pack::Pack,
-    pubkey::Pubkey,
-    signature::{Keypair, Signer},
-    transaction::Transaction,
+use {
+    setup::{account, mint, TOKEN_PROGRAM_ID},
+    solana_program_test::{tokio, ProgramTest},
+    solana_sdk::{
+        program_pack::Pack,
+        pubkey::Pubkey,
+        signature::{Keypair, Signer},
+        transaction::Transaction,
+    },
+    spl_token::state::AccountState,
 };
-use spl_token::state::AccountState;
 
 #[test_case::test_case(TOKEN_PROGRAM_ID ; "p-token")]
 #[tokio::test]

--- a/p-token/tests/initialize_account.rs
+++ b/p-token/tests/initialize_account.rs
@@ -1,13 +1,15 @@
 mod setup;
 
-use setup::{mint, TOKEN_PROGRAM_ID};
-use solana_program_test::{tokio, ProgramTest};
-use solana_sdk::{
-    program_pack::Pack,
-    pubkey::Pubkey,
-    signature::{Keypair, Signer},
-    system_instruction,
-    transaction::Transaction,
+use {
+    setup::{mint, TOKEN_PROGRAM_ID},
+    solana_program_test::{tokio, ProgramTest},
+    solana_sdk::{
+        program_pack::Pack,
+        pubkey::Pubkey,
+        signature::{Keypair, Signer},
+        system_instruction,
+        transaction::Transaction,
+    },
 };
 
 #[test_case::test_case(TOKEN_PROGRAM_ID ; "p-token")]

--- a/p-token/tests/initialize_account2.rs
+++ b/p-token/tests/initialize_account2.rs
@@ -1,13 +1,15 @@
 mod setup;
 
-use setup::{mint, TOKEN_PROGRAM_ID};
-use solana_program_test::{tokio, ProgramTest};
-use solana_sdk::{
-    program_pack::Pack,
-    pubkey::Pubkey,
-    signature::{Keypair, Signer},
-    system_instruction,
-    transaction::Transaction,
+use {
+    setup::{mint, TOKEN_PROGRAM_ID},
+    solana_program_test::{tokio, ProgramTest},
+    solana_sdk::{
+        program_pack::Pack,
+        pubkey::Pubkey,
+        signature::{Keypair, Signer},
+        system_instruction,
+        transaction::Transaction,
+    },
 };
 
 #[test_case::test_case(TOKEN_PROGRAM_ID ; "p-token")]

--- a/p-token/tests/initialize_account3.rs
+++ b/p-token/tests/initialize_account3.rs
@@ -1,13 +1,15 @@
 mod setup;
 
-use setup::{mint, TOKEN_PROGRAM_ID};
-use solana_program_test::{tokio, ProgramTest};
-use solana_sdk::{
-    program_pack::Pack,
-    pubkey::Pubkey,
-    signature::{Keypair, Signer},
-    system_instruction,
-    transaction::Transaction,
+use {
+    setup::{mint, TOKEN_PROGRAM_ID},
+    solana_program_test::{tokio, ProgramTest},
+    solana_sdk::{
+        program_pack::Pack,
+        pubkey::Pubkey,
+        signature::{Keypair, Signer},
+        system_instruction,
+        transaction::Transaction,
+    },
 };
 
 #[test_case::test_case(TOKEN_PROGRAM_ID ; "p-token")]

--- a/p-token/tests/initialize_mint.rs
+++ b/p-token/tests/initialize_mint.rs
@@ -1,18 +1,19 @@
 mod setup;
 
-use std::mem::size_of;
-
-use setup::TOKEN_PROGRAM_ID;
-use solana_program_test::{tokio, ProgramTest};
-use solana_sdk::{
-    program_option::COption,
-    program_pack::Pack,
-    pubkey::Pubkey,
-    signature::{Keypair, Signer},
-    system_instruction,
-    transaction::Transaction,
+use {
+    setup::TOKEN_PROGRAM_ID,
+    solana_program_test::{tokio, ProgramTest},
+    solana_sdk::{
+        program_option::COption,
+        program_pack::Pack,
+        pubkey::Pubkey,
+        signature::{Keypair, Signer},
+        system_instruction,
+        transaction::Transaction,
+    },
+    spl_token_interface::state::mint::Mint,
+    std::mem::size_of,
 };
-use spl_token_interface::state::mint::Mint;
 
 #[test_case::test_case(TOKEN_PROGRAM_ID ; "p-token")]
 #[tokio::test]

--- a/p-token/tests/initialize_mint2.rs
+++ b/p-token/tests/initialize_mint2.rs
@@ -1,18 +1,19 @@
 mod setup;
 
-use std::mem::size_of;
-
-use setup::TOKEN_PROGRAM_ID;
-use solana_program_test::{tokio, ProgramTest};
-use solana_sdk::{
-    program_option::COption,
-    program_pack::Pack,
-    pubkey::Pubkey,
-    signature::{Keypair, Signer},
-    system_instruction,
-    transaction::Transaction,
+use {
+    setup::TOKEN_PROGRAM_ID,
+    solana_program_test::{tokio, ProgramTest},
+    solana_sdk::{
+        program_option::COption,
+        program_pack::Pack,
+        pubkey::Pubkey,
+        signature::{Keypair, Signer},
+        system_instruction,
+        transaction::Transaction,
+    },
+    spl_token_interface::state::mint::Mint,
+    std::mem::size_of,
 };
-use spl_token_interface::state::mint::Mint;
 
 #[test_case::test_case(TOKEN_PROGRAM_ID ; "p-token")]
 #[tokio::test]

--- a/p-token/tests/initialize_multisig.rs
+++ b/p-token/tests/initialize_multisig.rs
@@ -1,15 +1,17 @@
 mod setup;
 
-use setup::TOKEN_PROGRAM_ID;
-use solana_program_test::{tokio, ProgramTest};
-use solana_sdk::{
-    program_pack::Pack,
-    pubkey::Pubkey,
-    signature::{Keypair, Signer},
-    system_instruction,
-    transaction::Transaction,
+use {
+    setup::TOKEN_PROGRAM_ID,
+    solana_program_test::{tokio, ProgramTest},
+    solana_sdk::{
+        program_pack::Pack,
+        pubkey::Pubkey,
+        signature::{Keypair, Signer},
+        system_instruction,
+        transaction::Transaction,
+    },
+    spl_token::state::Multisig,
 };
-use spl_token::state::Multisig;
 
 #[test_case::test_case(TOKEN_PROGRAM_ID ; "p-token")]
 #[tokio::test]

--- a/p-token/tests/initialize_multisig2.rs
+++ b/p-token/tests/initialize_multisig2.rs
@@ -1,15 +1,17 @@
 mod setup;
 
-use setup::TOKEN_PROGRAM_ID;
-use solana_program_test::{tokio, ProgramTest};
-use solana_sdk::{
-    program_pack::Pack,
-    pubkey::Pubkey,
-    signature::{Keypair, Signer},
-    system_instruction,
-    transaction::Transaction,
+use {
+    setup::TOKEN_PROGRAM_ID,
+    solana_program_test::{tokio, ProgramTest},
+    solana_sdk::{
+        program_pack::Pack,
+        pubkey::Pubkey,
+        signature::{Keypair, Signer},
+        system_instruction,
+        transaction::Transaction,
+    },
+    spl_token::state::Multisig,
 };
-use spl_token::state::Multisig;
 
 #[test_case::test_case(TOKEN_PROGRAM_ID ; "p-token")]
 #[tokio::test]

--- a/p-token/tests/mint_to.rs
+++ b/p-token/tests/mint_to.rs
@@ -1,12 +1,14 @@
 mod setup;
 
-use setup::{account, mint, TOKEN_PROGRAM_ID};
-use solana_program_test::{tokio, ProgramTest};
-use solana_sdk::{
-    program_pack::Pack,
-    pubkey::Pubkey,
-    signature::{Keypair, Signer},
-    transaction::Transaction,
+use {
+    setup::{account, mint, TOKEN_PROGRAM_ID},
+    solana_program_test::{tokio, ProgramTest},
+    solana_sdk::{
+        program_pack::Pack,
+        pubkey::Pubkey,
+        signature::{Keypair, Signer},
+        transaction::Transaction,
+    },
 };
 
 #[test_case::test_case(TOKEN_PROGRAM_ID ; "p-token")]

--- a/p-token/tests/mint_to_checked.rs
+++ b/p-token/tests/mint_to_checked.rs
@@ -1,12 +1,14 @@
 mod setup;
 
-use setup::{account, mint, TOKEN_PROGRAM_ID};
-use solana_program_test::{tokio, ProgramTest};
-use solana_sdk::{
-    program_pack::Pack,
-    pubkey::Pubkey,
-    signature::{Keypair, Signer},
-    transaction::Transaction,
+use {
+    setup::{account, mint, TOKEN_PROGRAM_ID},
+    solana_program_test::{tokio, ProgramTest},
+    solana_sdk::{
+        program_pack::Pack,
+        pubkey::Pubkey,
+        signature::{Keypair, Signer},
+        transaction::Transaction,
+    },
 };
 
 #[test_case::test_case(TOKEN_PROGRAM_ID ; "p-token")]

--- a/p-token/tests/revoke.rs
+++ b/p-token/tests/revoke.rs
@@ -1,12 +1,14 @@
 mod setup;
 
-use setup::{account, mint, TOKEN_PROGRAM_ID};
-use solana_program_test::{tokio, ProgramTest};
-use solana_sdk::{
-    program_pack::Pack,
-    pubkey::Pubkey,
-    signature::{Keypair, Signer},
-    transaction::Transaction,
+use {
+    setup::{account, mint, TOKEN_PROGRAM_ID},
+    solana_program_test::{tokio, ProgramTest},
+    solana_sdk::{
+        program_pack::Pack,
+        pubkey::Pubkey,
+        signature::{Keypair, Signer},
+        transaction::Transaction,
+    },
 };
 
 #[test_case::test_case(TOKEN_PROGRAM_ID ; "p-token")]

--- a/p-token/tests/set_authority.rs
+++ b/p-token/tests/set_authority.rs
@@ -1,15 +1,17 @@
 mod setup;
 
-use setup::{mint, TOKEN_PROGRAM_ID};
-use solana_program_test::{tokio, ProgramTest};
-use solana_sdk::{
-    program_option::COption,
-    program_pack::Pack,
-    pubkey::Pubkey,
-    signature::{Keypair, Signer},
-    transaction::Transaction,
+use {
+    setup::{mint, TOKEN_PROGRAM_ID},
+    solana_program_test::{tokio, ProgramTest},
+    solana_sdk::{
+        program_option::COption,
+        program_pack::Pack,
+        pubkey::Pubkey,
+        signature::{Keypair, Signer},
+        transaction::Transaction,
+    },
+    spl_token::instruction::AuthorityType,
 };
-use spl_token::instruction::AuthorityType;
 
 #[test_case::test_case(TOKEN_PROGRAM_ID ; "p-token")]
 #[tokio::test]

--- a/p-token/tests/setup/account.rs
+++ b/p-token/tests/setup/account.rs
@@ -1,7 +1,9 @@
-use solana_program_test::ProgramTestContext;
-use solana_sdk::{
-    pubkey::Pubkey, signature::Keypair, signer::Signer, system_instruction,
-    transaction::Transaction,
+use {
+    solana_program_test::ProgramTestContext,
+    solana_sdk::{
+        pubkey::Pubkey, signature::Keypair, signer::Signer, system_instruction,
+        transaction::Transaction,
+    },
 };
 
 pub async fn initialize(

--- a/p-token/tests/setup/mint.rs
+++ b/p-token/tests/setup/mint.rs
@@ -1,11 +1,12 @@
-use std::mem::size_of;
-
-use solana_program_test::{BanksClientError, ProgramTestContext};
-use solana_sdk::{
-    program_error::ProgramError, pubkey::Pubkey, signature::Keypair, signer::Signer,
-    system_instruction, transaction::Transaction,
+use {
+    solana_program_test::{BanksClientError, ProgramTestContext},
+    solana_sdk::{
+        program_error::ProgramError, pubkey::Pubkey, signature::Keypair, signer::Signer,
+        system_instruction, transaction::Transaction,
+    },
+    spl_token_interface::state::mint::Mint,
+    std::mem::size_of,
 };
-use spl_token_interface::state::mint::Mint;
 
 pub async fn initialize(
     context: &mut ProgramTestContext,

--- a/p-token/tests/thaw_account.rs
+++ b/p-token/tests/thaw_account.rs
@@ -1,14 +1,16 @@
 mod setup;
 
-use setup::{account, mint, TOKEN_PROGRAM_ID};
-use solana_program_test::{tokio, ProgramTest};
-use solana_sdk::{
-    program_pack::Pack,
-    pubkey::Pubkey,
-    signature::{Keypair, Signer},
-    transaction::Transaction,
+use {
+    setup::{account, mint, TOKEN_PROGRAM_ID},
+    solana_program_test::{tokio, ProgramTest},
+    solana_sdk::{
+        program_pack::Pack,
+        pubkey::Pubkey,
+        signature::{Keypair, Signer},
+        transaction::Transaction,
+    },
+    spl_token::state::AccountState,
 };
-use spl_token::state::AccountState;
 
 #[test_case::test_case(TOKEN_PROGRAM_ID ; "p-token")]
 #[tokio::test]

--- a/p-token/tests/transfer.rs
+++ b/p-token/tests/transfer.rs
@@ -1,12 +1,14 @@
 mod setup;
 
-use setup::{account, mint, TOKEN_PROGRAM_ID};
-use solana_program_test::{tokio, ProgramTest};
-use solana_sdk::{
-    program_pack::Pack,
-    pubkey::Pubkey,
-    signature::{Keypair, Signer},
-    transaction::Transaction,
+use {
+    setup::{account, mint, TOKEN_PROGRAM_ID},
+    solana_program_test::{tokio, ProgramTest},
+    solana_sdk::{
+        program_pack::Pack,
+        pubkey::Pubkey,
+        signature::{Keypair, Signer},
+        transaction::Transaction,
+    },
 };
 
 #[test_case::test_case(TOKEN_PROGRAM_ID ; "p-token")]

--- a/p-token/tests/transfer_checked.rs
+++ b/p-token/tests/transfer_checked.rs
@@ -1,12 +1,14 @@
 mod setup;
 
-use setup::{account, mint, TOKEN_PROGRAM_ID};
-use solana_program_test::{tokio, ProgramTest};
-use solana_sdk::{
-    program_pack::Pack,
-    pubkey::Pubkey,
-    signature::{Keypair, Signer},
-    transaction::Transaction,
+use {
+    setup::{account, mint, TOKEN_PROGRAM_ID},
+    solana_program_test::{tokio, ProgramTest},
+    solana_sdk::{
+        program_pack::Pack,
+        pubkey::Pubkey,
+        signature::{Keypair, Signer},
+        transaction::Transaction,
+    },
 };
 
 #[test_case::test_case(TOKEN_PROGRAM_ID ; "p-token")]

--- a/p-token/tests/ui_amount_to_amount.rs
+++ b/p-token/tests/ui_amount_to_amount.rs
@@ -1,8 +1,10 @@
 mod setup;
 
-use setup::{mint, TOKEN_PROGRAM_ID};
-use solana_program_test::{tokio, ProgramTest};
-use solana_sdk::{pubkey::Pubkey, signature::Signer, transaction::Transaction};
+use {
+    setup::{mint, TOKEN_PROGRAM_ID},
+    solana_program_test::{tokio, ProgramTest},
+    solana_sdk::{pubkey::Pubkey, signature::Signer, transaction::Transaction},
+};
 
 #[test_case::test_case(TOKEN_PROGRAM_ID ; "p-token")]
 #[tokio::test]

--- a/p-token/tests/withdraw_excess_lamports.rs
+++ b/p-token/tests/withdraw_excess_lamports.rs
@@ -1,17 +1,19 @@
 mod setup;
 
-use assert_matches::assert_matches;
-use setup::{mint, TOKEN_PROGRAM_ID};
-use solana_program_test::{tokio, BanksClientError, ProgramTest};
-use solana_sdk::{
-    instruction::InstructionError,
-    pubkey::Pubkey,
-    signature::{Keypair, Signer},
-    system_instruction,
-    transaction::{Transaction, TransactionError},
+use {
+    assert_matches::assert_matches,
+    setup::{mint, TOKEN_PROGRAM_ID},
+    solana_program_test::{tokio, BanksClientError, ProgramTest},
+    solana_sdk::{
+        instruction::InstructionError,
+        pubkey::Pubkey,
+        signature::{Keypair, Signer},
+        system_instruction,
+        transaction::{Transaction, TransactionError},
+    },
+    spl_token_interface::state::{account::Account, mint::Mint, multisig::Multisig},
+    std::mem::size_of,
 };
-use spl_token_interface::state::{account::Account, mint::Mint, multisig::Multisig};
-use std::mem::size_of;
 
 #[test_case::test_case(TOKEN_PROGRAM_ID ; "p-token")]
 #[tokio::test]

--- a/p-token/tests/withdraw_excess_lamports.rs
+++ b/p-token/tests/withdraw_excess_lamports.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::arithmetic_side_effects)]
+
 mod setup;
 
 use {

--- a/package.json
+++ b/package.json
@@ -25,10 +25,15 @@
     "rust:publish": "zx ./scripts/rust/publish.mjs",
     "rust:semver": "cargo semver-checks",
     "p-token:build": "zx ./scripts/rust/build-sbf.mjs p-token",
+    "p-token:format": "zx ./scripts/rust/format.mjs p-token",
+    "p-token:lint": "zx ./scripts/rust/lint.mjs p-token",
     "p-token:test": "zx ./scripts/rust/test.mjs p-token",
     "fixtures:clean": "zx ./scripts/rust/fixtures.mjs clean",
     "fixtures:generate": "zx ./scripts/rust/fixtures.mjs generate",
-    "fixtures:run": "zx ./scripts/rust/fixtures.mjs run"
+    "fixtures:run": "zx ./scripts/rust/fixtures.mjs run",
+    "interface:format": "zx ./scripts/rust/format.mjs interface",
+    "interface:lint": "zx ./scripts/rust/lint.mjs interface"
+
   },
   "devDependencies": {
     "@codama/renderers-js": "^1.2.7",


### PR DESCRIPTION
### Problem

Currently, both the `interface` and `p-token` are not being checked for lint issues on the CI.

### Solution

Add `interface` and `p-token` lint jobs to the CI. This included:
* Fixing current format issues
* Fixing clippy warnings
* Adding the scripts to `package.json`
* Updating the main workflow