### PR TITLE
interface: Add `no_std` attribute

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1336,18 +1336,18 @@ dependencies = [
 
 [[package]]
 name = "five8_const"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b4f62f0f8ca357f93ae90c8c2dd1041a1f665fde2f889ea9b1787903829015"
+checksum = "26dec3da8bc3ef08f2c04f61eab298c3ab334523e55f076354d6d6f613799a7b"
 dependencies = [
  "five8_core",
 ]
 
 [[package]]
 name = "five8_core"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94474d15a76982be62ca8a39570dccce148d98c238ebb7408b0a21b2c4bdddc4"
+checksum = "2551bf44bc5f776c15044b9b94153a00198be06743e262afaaa61f11ac7523a5"
 
 [[package]]
 name = "flate2"
@@ -2817,9 +2817,9 @@ checksum = "f89f8ffd986174cefe59448295a004aaf70c3605f30de066f42d27b06188f267"
 
 [[package]]
 name = "pinocchio-pubkey"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c8cd934ccaf7915d19049275f77c8888860a2792102a5d9f0b8eafbf670f6a8"
+checksum = "0c6b20fcebc172c3cd3f54114b0241b48fa8e30893ced2eb4927aaba5e3a0ba5"
 dependencies = [
  "five8_const",
  "pinocchio",

--- a/interface/Cargo.toml
+++ b/interface/Cargo.toml
@@ -13,7 +13,7 @@ crate-type = ["rlib"]
 
 [dependencies]
 pinocchio = "0.8"
-pinocchio-pubkey = "0.2"
+pinocchio-pubkey = "0.2.4"
 
 [dev-dependencies]
 strum = "0.27"

--- a/interface/src/lib.rs
+++ b/interface/src/lib.rs
@@ -1,3 +1,5 @@
+#![no_std]
+
 pub mod error;
 pub mod instruction;
 pub mod native_mint;

--- a/p-token/src/entrypoint.rs
+++ b/p-token/src/entrypoint.rs
@@ -2,7 +2,7 @@ use {
     crate::processor::*,
     pinocchio::{
         account_info::AccountInfo,
-        default_panic_handler, no_allocator, program_entrypoint,
+        no_allocator, nostd_panic_handler, program_entrypoint,
         program_error::{ProgramError, ToStr},
         pubkey::Pubkey,
         ProgramResult,
@@ -13,8 +13,8 @@ use {
 program_entrypoint!(process_instruction);
 // Do not allocate memory.
 no_allocator!();
-// Use the default panic handler.
-default_panic_handler!();
+// Use the no_std panic handler.
+nostd_panic_handler!();
 
 /// Log an error.
 #[cold]


### PR DESCRIPTION
### Problem

Currently the interface crate is no_std "friendly", but it is missing the no_std attribute. This brings the `std` during the link stage and prevents the program from using the `nostd_panic_handler`.

### Solution

Add the no_std attribute to the interface crate, update the dependencies so all of them are compatible with no_std and use the `nostd_panic_handler` on p-token.