### PR TITLE
CI: Fix semver checks to use a script

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "rust:spellcheck": "cargo spellcheck --code 1",
     "rust:audit": "zx ./scripts/rust/audit.mjs",
     "rust:publish": "zx ./scripts/rust/publish.mjs",
-    "rust:semver": "cargo semver-checks",
+    "rust:semver": "zx ./scripts/rust/semver.mjs",
     "p-token:build": "zx ./scripts/rust/build-sbf.mjs p-token",
     "p-token:format": "zx ./scripts/rust/format.mjs p-token",
     "p-token:lint": "zx ./scripts/rust/lint.mjs p-token",

--- a/scripts/rust/semver.mjs
+++ b/scripts/rust/semver.mjs
@@ -1,0 +1,7 @@
+#!/usr/bin/env zx
+import 'zx/globals';
+import { cliArguments, getCargo, workingDirectory } from '../utils.mjs';
+
+const [folder, ...args] = cliArguments();
+const manifestPath = path.join(workingDirectory, folder, 'Cargo.toml');
+await $`cargo semver-checks --manifest-path ${manifestPath} ${args}`;


### PR DESCRIPTION
#### Problem

The semver checks step during publish is broken because it's simply passing in the folder, but there's some additional work needed to decompose it into a manifest path.

#### Summary of changes

Similar to many other repos, add a semver script which will pull out the manifest given a path.