### PR TITLE
CI: Set git author / email before bump

### DIFF
--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -89,6 +89,11 @@ jobs:
         with:
           tool: cargo-semver-checks,cargo-release
 
+      - name: Set Git Author (required for cargo-release)
+        run: |
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
+
       - name: Set Version
         run: |
           if [ "${{ inputs.level }}" == "version" ]; then


### PR DESCRIPTION
#### Problem

cargo-release requires git identification to be set, even if it won't be used.

#### Summary of changes

Set the name and email.