### PR TITLE
p-token: Tweaks to processors

### DIFF
--- a/p-token/src/entrypoint.rs
+++ b/p-token/src/entrypoint.rs
@@ -110,12 +110,33 @@ pub(crate) fn inner_process_instruction(
 
             process_mint_to(accounts, instruction_data)
         }
+        // 8 - Burn
+        8 => {
+            #[cfg(feature = "logging")]
+            pinocchio::msg!("Instruction: Burn");
+
+            process_burn(accounts, instruction_data)
+        }
         // 9 - CloseAccount
         9 => {
             #[cfg(feature = "logging")]
             pinocchio::msg!("Instruction: CloseAccount");
 
             process_close_account(accounts)
+        }
+        // 12 - TransferChecked
+        12 => {
+            #[cfg(feature = "logging")]
+            pinocchio::msg!("Instruction: TransferChecked");
+
+            process_transfer_checked(accounts, instruction_data)
+        }
+        // 15 - BurnChecked
+        15 => {
+            #[cfg(feature = "logging")]
+            pinocchio::msg!("Instruction: BurnChecked");
+
+            process_burn_checked(accounts, instruction_data)
         }
         // 16 - InitializeAccount2
         16 => {
@@ -182,13 +203,6 @@ fn inner_process_remaining_instruction(
 
             process_set_authority(accounts, instruction_data)
         }
-        // 8 - Burn
-        8 => {
-            #[cfg(feature = "logging")]
-            pinocchio::msg!("Instruction: Burn");
-
-            process_burn(accounts, instruction_data)
-        }
         // 10 - FreezeAccount
         10 => {
             #[cfg(feature = "logging")]
@@ -203,13 +217,6 @@ fn inner_process_remaining_instruction(
 
             process_thaw_account(accounts)
         }
-        // 12 - TransferChecked
-        12 => {
-            #[cfg(feature = "logging")]
-            pinocchio::msg!("Instruction: TransferChecked");
-
-            process_transfer_checked(accounts, instruction_data)
-        }
         // 13 - ApproveChecked
         13 => {
             #[cfg(feature = "logging")]
@@ -223,13 +230,6 @@ fn inner_process_remaining_instruction(
             pinocchio::msg!("Instruction: MintToChecked");
 
             process_mint_to_checked(accounts, instruction_data)
-        }
-        // 15 - BurnChecked
-        15 => {
-            #[cfg(feature = "logging")]
-            pinocchio::msg!("Instruction: BurnChecked");
-
-            process_burn_checked(accounts, instruction_data)
         }
         // 17 - SyncNative
         17 => {

--- a/p-token/src/processor/amount_to_ui_amount.rs
+++ b/p-token/src/processor/amount_to_ui_amount.rs
@@ -12,7 +12,6 @@ use {
     },
 };
 
-#[inline(always)]
 pub fn process_amount_to_ui_amount(
     accounts: &[AccountInfo],
     instruction_data: &[u8],

--- a/p-token/src/processor/initialize_multisig2.rs
+++ b/p-token/src/processor/initialize_multisig2.rs
@@ -3,7 +3,6 @@ use {
     pinocchio::{account_info::AccountInfo, program_error::ProgramError, ProgramResult},
 };
 
-#[inline(always)]
 pub fn process_initialize_multisig2(
     accounts: &[AccountInfo],
     instruction_data: &[u8],

--- a/p-token/src/processor/ui_amount_to_amount.rs
+++ b/p-token/src/processor/ui_amount_to_amount.rs
@@ -11,7 +11,6 @@ use {
     },
 };
 
-#[inline(always)]
 pub fn process_ui_amount_to_amount(
     accounts: &[AccountInfo],
     instruction_data: &[u8],

--- a/p-token/src/processor/withdraw_excess_lamports.rs
+++ b/p-token/src/processor/withdraw_excess_lamports.rs
@@ -12,7 +12,6 @@ use {
     },
 };
 
-#[inline(always)]
 #[allow(clippy::arithmetic_side_effects)]
 pub fn process_withdraw_excess_lamports(accounts: &[AccountInfo]) -> ProgramResult {
     let [source_account_info, destination_info, authority_info, remaining @ ..] = accounts else {


### PR DESCRIPTION
### Problem

`p-token` processor is divided into "fast" and "normal", where the "fast" is responsible for a small subset of instructions to reduce the number of comparisons to determine which instruction to execute. Instructions that are not placed on the "fast" tend to have CU overhead, therefore popular instructions such as `transfer_checked`, `burn` and `burn_checked` should be placed on the "fast" path.

### Solution

Move `transfer_checked`, `burn` and `burn_checked` to the "fast" processor. This PR also removes `inline` attributes of some processors where there are no gains in CUs for doing that.