### PR TITLE
p-token: Fix error codes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2805,9 +2805,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pinocchio"
-version = "0.8.0"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2281a8e9e947c480ce0b64e2d6c6349d72890ba5db6503d5568edf96f304cba9"
+checksum = "7c33b58567c11b07749cefbb8320ac023f3387c57807aeb8e3b1262501b6e9f0"
 
 [[package]]
 name = "pinocchio-log"

--- a/interface/Cargo.toml
+++ b/interface/Cargo.toml
@@ -12,8 +12,8 @@ readme = "./README.md"
 crate-type = ["rlib"]
 
 [dependencies]
-pinocchio = "0.8"
-pinocchio-pubkey = "0.2.4"
+pinocchio = "0.8.4"
+pinocchio-pubkey = "0.2"
 
 [dev-dependencies]
 strum = "0.27"

--- a/interface/src/error.rs
+++ b/interface/src/error.rs
@@ -124,7 +124,7 @@ impl TryFrom<u32> for TokenError {
             17 => Ok(TokenError::AccountFrozen),
             18 => Ok(TokenError::MintDecimalsMismatch),
             19 => Ok(TokenError::NonNativeNotSupported),
-            _ => Err(TokenError::InvalidInstruction.into()),
+            _ => Err(ProgramError::InvalidArgument),
         }
     }
 }

--- a/interface/src/error.rs
+++ b/interface/src/error.rs
@@ -124,7 +124,7 @@ impl TryFrom<u32> for TokenError {
             17 => Ok(TokenError::AccountFrozen),
             18 => Ok(TokenError::MintDecimalsMismatch),
             19 => Ok(TokenError::NonNativeNotSupported),
-            _ => Err(ProgramError::InvalidArgument),
+            _ => Err(TokenError::InvalidInstruction.into()),
         }
     }
 }

--- a/interface/src/instruction.rs
+++ b/interface/src/instruction.rs
@@ -1,8 +1,6 @@
 //! Instruction types.
 
-use pinocchio::program_error::ProgramError;
-
-use crate::error::TokenError;
+use {crate::error::TokenError, pinocchio::program_error::ProgramError};
 
 /// Instructions supported by the token program.
 #[repr(u8)]

--- a/interface/src/instruction.rs
+++ b/interface/src/instruction.rs
@@ -2,6 +2,8 @@
 
 use pinocchio::program_error::ProgramError;
 
+use crate::error::TokenError;
+
 /// Instructions supported by the token program.
 #[repr(u8)]
 #[derive(Clone, Debug, PartialEq)]
@@ -531,7 +533,7 @@ impl TryFrom<u8> for TokenInstruction {
         match value {
             // SAFETY: `value` is guaranteed to be in the range of the enum variants.
             0..=24 | 38 | 255 => Ok(unsafe { core::mem::transmute::<u8, TokenInstruction>(value) }),
-            _ => Err(ProgramError::InvalidInstructionData),
+            _ => Err(TokenError::InvalidInstruction.into()),
         }
     }
 }
@@ -559,7 +561,7 @@ impl TryFrom<u8> for AuthorityType {
         match value {
             // SAFETY: `value` is guaranteed to be in the range of the enum variants.
             0..=3 => Ok(unsafe { core::mem::transmute::<u8, AuthorityType>(value) }),
-            _ => Err(ProgramError::InvalidInstructionData),
+            _ => Err(TokenError::InvalidInstruction.into()),
         }
     }
 }

--- a/interface/src/state/account.rs
+++ b/interface/src/state/account.rs
@@ -1,5 +1,5 @@
 use {
-    super::{account_state::AccountState, validate_option, COption, Initializable, Transmutable},
+    super::{account_state::AccountState, COption, Initializable, Transmutable},
     pinocchio::{program_error::ProgramError, pubkey::Pubkey},
 };
 
@@ -142,7 +142,7 @@ impl Account {
 
     #[inline(always)]
     pub fn is_frozen(&self) -> Result<bool, ProgramError> {
-        Ok(AccountState::try_from(self.state)? == AccountState::Frozen)
+        AccountState::try_from(self.state).map(|state| state == AccountState::Frozen)
     }
 
     #[inline(always)]
@@ -158,18 +158,6 @@ impl Transmutable for Account {
 impl Initializable for Account {
     #[inline(always)]
     fn is_initialized(&self) -> Result<bool, ProgramError> {
-        // delegate
-        validate_option(self.delegate.0)?;
-
-        // state
-        let state = AccountState::try_from(self.state)?;
-
-        // is_native
-        validate_option(self.is_native)?;
-
-        // close authority
-        validate_option(self.close_authority.0)?;
-
-        Ok(state != AccountState::Uninitialized)
+        AccountState::try_from(self.state).map(|state| state != AccountState::Uninitialized)
     }
 }

--- a/interface/src/state/account.rs
+++ b/interface/src/state/account.rs
@@ -1,5 +1,5 @@
 use {
-    super::{account_state::AccountState, COption, Initializable, Transmutable},
+    super::{account_state::AccountState, validate_option, COption, Initializable, Transmutable},
     pinocchio::{program_error::ProgramError, pubkey::Pubkey},
 };
 
@@ -159,24 +159,16 @@ impl Initializable for Account {
     #[inline(always)]
     fn is_initialized(&self) -> Result<bool, ProgramError> {
         // delegate
-        match self.delegate.0 {
-            [0, 0, 0, 0] | [1, 0, 0, 0] => (),
-            _ => return Err(ProgramError::InvalidAccountData),
-        }
+        validate_option(self.delegate.0)?;
+
         // state
         let state = AccountState::try_from(self.state)?;
 
         // is_native
-        match self.is_native {
-            [0, 0, 0, 0] | [1, 0, 0, 0] => (),
-            _ => return Err(ProgramError::InvalidAccountData),
-        }
+        validate_option(self.is_native)?;
 
         // close authority
-        match self.close_authority.0 {
-            [0, 0, 0, 0] | [1, 0, 0, 0] => (),
-            _ => return Err(ProgramError::InvalidAccountData),
-        }
+        validate_option(self.close_authority.0)?;
 
         Ok(state != AccountState::Uninitialized)
     }

--- a/interface/src/state/account_state.rs
+++ b/interface/src/state/account_state.rs
@@ -1,3 +1,5 @@
+use pinocchio::program_error::ProgramError;
+
 #[repr(u8)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum AccountState {
@@ -12,4 +14,17 @@ pub enum AccountState {
     /// account owner nor the delegate are able to perform operations on
     /// this account.
     Frozen,
+}
+
+impl TryFrom<u8> for AccountState {
+    type Error = ProgramError;
+
+    #[inline(always)]
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            // SAFETY: `value` is guaranteed to be in the range of the enum variants.
+            0..=2 => Ok(unsafe { core::mem::transmute::<u8, AccountState>(value) }),
+            _ => Err(ProgramError::InvalidAccountData),
+        }
+    }
 }

--- a/interface/src/state/mint.rs
+++ b/interface/src/state/mint.rs
@@ -1,5 +1,5 @@
 use {
-    super::{COption, Initializable, Transmutable},
+    super::{validate_option, COption, Initializable, Transmutable},
     pinocchio::{program_error::ProgramError, pubkey::Pubkey},
 };
 
@@ -93,10 +93,7 @@ impl Initializable for Mint {
     #[inline(always)]
     fn is_initialized(&self) -> Result<bool, ProgramError> {
         // mint_authority
-        match self.mint_authority.0 {
-            [0, 0, 0, 0] | [1, 0, 0, 0] => (),
-            _ => return Err(ProgramError::InvalidAccountData),
-        }
+        validate_option(self.mint_authority.0)?;
 
         // is_initialized
         let initialized = match self.is_initialized {
@@ -106,10 +103,7 @@ impl Initializable for Mint {
         };
 
         // freeze_authority
-        match self.freeze_authority.0 {
-            [0, 0, 0, 0] | [1, 0, 0, 0] => (),
-            _ => return Err(ProgramError::InvalidAccountData),
-        }
+        validate_option(self.freeze_authority.0)?;
 
         Ok(initialized)
     }

--- a/interface/src/state/mint.rs
+++ b/interface/src/state/mint.rs
@@ -1,5 +1,5 @@
 use {
-    super::{validate_option, COption, Initializable, Transmutable},
+    super::{COption, Initializable, Transmutable},
     pinocchio::{program_error::ProgramError, pubkey::Pubkey},
 };
 
@@ -92,19 +92,10 @@ impl Transmutable for Mint {
 impl Initializable for Mint {
     #[inline(always)]
     fn is_initialized(&self) -> Result<bool, ProgramError> {
-        // mint_authority
-        validate_option(self.mint_authority.0)?;
-
-        // is_initialized
-        let initialized = match self.is_initialized {
-            0 => false,
-            1 => true,
-            _ => return Err(ProgramError::InvalidAccountData),
-        };
-
-        // freeze_authority
-        validate_option(self.freeze_authority.0)?;
-
-        Ok(initialized)
+        match self.is_initialized {
+            0 => Ok(false),
+            1 => Ok(true),
+            _ => Err(ProgramError::InvalidAccountData),
+        }
     }
 }

--- a/interface/src/state/mint.rs
+++ b/interface/src/state/mint.rs
@@ -55,11 +55,11 @@ impl Mint {
     }
 
     #[inline(always)]
-    pub fn mint_authority(&self) -> Result<Option<&Pubkey>, ProgramError> {
-        match self.mint_authority.0 {
-            [0, 0, 0, 0] => Ok(None),
-            [1, 0, 0, 0] => Ok(Some(&self.mint_authority.1)),
-            _ => Err(ProgramError::InvalidAccountData),
+    pub fn mint_authority(&self) -> Option<&Pubkey> {
+        if self.mint_authority.0[0] == 1 {
+            Some(&self.mint_authority.1)
+        } else {
+            None
         }
     }
 
@@ -75,11 +75,11 @@ impl Mint {
     }
 
     #[inline(always)]
-    pub fn freeze_authority(&self) -> Result<Option<&Pubkey>, ProgramError> {
-        match self.freeze_authority.0 {
-            [0, 0, 0, 0] => Ok(None),
-            [1, 0, 0, 0] => Ok(Some(&self.freeze_authority.1)),
-            _ => Err(ProgramError::InvalidAccountData),
+    pub fn freeze_authority(&self) -> Option<&Pubkey> {
+        if self.freeze_authority.0[0] == 1 {
+            Some(&self.freeze_authority.1)
+        } else {
+            None
         }
     }
 }
@@ -92,10 +92,25 @@ impl Transmutable for Mint {
 impl Initializable for Mint {
     #[inline(always)]
     fn is_initialized(&self) -> Result<bool, ProgramError> {
-        match self.is_initialized {
-            0 => Ok(false),
-            1 => Ok(true),
-            _ => Err(ProgramError::InvalidAccountData),
+        // mint_authority
+        match self.mint_authority.0 {
+            [0, 0, 0, 0] | [1, 0, 0, 0] => (),
+            _ => return Err(ProgramError::InvalidAccountData),
         }
+
+        // is_initialized
+        let initialized = match self.is_initialized {
+            0 => false,
+            1 => true,
+            _ => return Err(ProgramError::InvalidAccountData),
+        };
+
+        // freeze_authority
+        match self.freeze_authority.0 {
+            [0, 0, 0, 0] | [1, 0, 0, 0] => (),
+            _ => return Err(ProgramError::InvalidAccountData),
+        }
+
+        Ok(initialized)
     }
 }

--- a/interface/src/state/mod.rs
+++ b/interface/src/state/mod.rs
@@ -22,9 +22,9 @@ pub trait Transmutable {
 
 /// Trait to represent a type that can be initialized.
 ///
-/// Types implementing this trait must provide a method to check if the object is
-/// initialized, i.e., if all required fields are set to valid values and they
-/// represent an initialized state.
+/// Types implementing this trait must provide a method to check if the object
+/// is initialized, i.e., if all required fields are set to valid values and
+/// they represent an initialized state.
 pub trait Initializable {
     /// Return `true` if the object is initialized.
     fn is_initialized(&self) -> Result<bool, ProgramError>;

--- a/interface/src/state/mod.rs
+++ b/interface/src/state/mod.rs
@@ -21,6 +21,10 @@ pub trait Transmutable {
 }
 
 /// Trait to represent a type that can be initialized.
+///
+/// Types implementing this trait must provide a method to check if the object is
+/// initialized, i.e., if all required fields are set to valid values and they
+/// represent an initialized state.
 pub trait Initializable {
     /// Return `true` if the object is initialized.
     fn is_initialized(&self) -> Result<bool, ProgramError>;

--- a/interface/src/state/mod.rs
+++ b/interface/src/state/mod.rs
@@ -1,4 +1,4 @@
-use pinocchio::program_error::ProgramError;
+use pinocchio::{program_error::ProgramError, ProgramResult};
 
 pub mod account;
 pub mod account_state;
@@ -96,4 +96,14 @@ pub unsafe fn load_mut_unchecked<T: Transmutable>(
         return Err(ProgramError::InvalidAccountData);
     }
     Ok(&mut *(bytes.as_mut_ptr() as *mut T))
+}
+
+/// Validates a `COption` mask value.
+#[inline(always)]
+const fn validate_option(value: [u8; 4]) -> ProgramResult {
+    if u32::from_le_bytes(value) > 1 {
+        Err(ProgramError::InvalidAccountData)
+    } else {
+        Ok(())
+    }
 }

--- a/interface/src/state/mod.rs
+++ b/interface/src/state/mod.rs
@@ -1,4 +1,4 @@
-use pinocchio::{program_error::ProgramError, ProgramResult};
+use pinocchio::program_error::ProgramError;
 
 pub mod account;
 pub mod account_state;
@@ -21,10 +21,6 @@ pub trait Transmutable {
 }
 
 /// Trait to represent a type that can be initialized.
-///
-/// Types implementing this trait must provide a method to check if the object
-/// is initialized, i.e., if all required fields are set to valid values and
-/// they represent an initialized state.
 pub trait Initializable {
     /// Return `true` if the object is initialized.
     fn is_initialized(&self) -> Result<bool, ProgramError>;
@@ -96,14 +92,4 @@ pub unsafe fn load_mut_unchecked<T: Transmutable>(
         return Err(ProgramError::InvalidAccountData);
     }
     Ok(&mut *(bytes.as_mut_ptr() as *mut T))
-}
-
-/// Validates a `COption` mask value.
-#[inline(always)]
-const fn validate_option(value: [u8; 4]) -> ProgramResult {
-    if u32::from_le_bytes(value) > 1 {
-        Err(ProgramError::InvalidAccountData)
-    } else {
-        Ok(())
-    }
 }

--- a/interface/src/state/mod.rs
+++ b/interface/src/state/mod.rs
@@ -23,7 +23,7 @@ pub trait Transmutable {
 /// Trait to represent a type that can be initialized.
 pub trait Initializable {
     /// Return `true` if the object is initialized.
-    fn is_initialized(&self) -> bool;
+    fn is_initialized(&self) -> Result<bool, ProgramError>;
 }
 
 /// Return a reference for an initialized `T` from the given bytes.
@@ -35,7 +35,7 @@ pub trait Initializable {
 pub unsafe fn load<T: Initializable + Transmutable>(bytes: &[u8]) -> Result<&T, ProgramError> {
     load_unchecked(bytes).and_then(|t: &T| {
         // checks if the data is initialized
-        if t.is_initialized() {
+        if t.is_initialized()? {
             Ok(t)
         } else {
             Err(ProgramError::UninitializedAccount)
@@ -69,7 +69,7 @@ pub unsafe fn load_mut<T: Initializable + Transmutable>(
 ) -> Result<&mut T, ProgramError> {
     load_mut_unchecked(bytes).and_then(|t: &mut T| {
         // checks if the data is initialized
-        if t.is_initialized() {
+        if t.is_initialized()? {
             Ok(t)
         } else {
             Err(ProgramError::UninitializedAccount)

--- a/interface/src/state/multisig.rs
+++ b/interface/src/state/multisig.rs
@@ -1,6 +1,6 @@
 use {
     super::{Initializable, Transmutable},
-    pinocchio::pubkey::Pubkey,
+    pinocchio::{program_error::ProgramError, pubkey::Pubkey},
 };
 
 /// Minimum number of multisignature signers (min N)
@@ -18,10 +18,10 @@ pub struct Multisig {
     /// Number of valid signers.
     pub n: u8,
 
-    /// Is `true` if this structure has been initialized
+    /// Is `true` if this structure has been initialized.
     is_initialized: u8,
 
-    /// Signer public keys
+    /// Signer public keys.
     pub signers: [Pubkey; MAX_SIGNERS as usize],
 }
 
@@ -45,7 +45,11 @@ impl Transmutable for Multisig {
 
 impl Initializable for Multisig {
     #[inline(always)]
-    fn is_initialized(&self) -> bool {
-        self.is_initialized == 1
+    fn is_initialized(&self) -> Result<bool, ProgramError> {
+        match self.is_initialized {
+            0 => Ok(false),
+            1 => Ok(true),
+            _ => Err(ProgramError::InvalidAccountData),
+        }
     }
 }

--- a/interface/src/state/multisig.rs
+++ b/interface/src/state/multisig.rs
@@ -39,7 +39,7 @@ impl Multisig {
 }
 
 impl Transmutable for Multisig {
-    /// The length of the `Mint` account data.
+    /// The length of the `Multisig` account data.
     const LEN: usize = core::mem::size_of::<Multisig>();
 }
 

--- a/interface/src/state/multisig.rs
+++ b/interface/src/state/multisig.rs
@@ -46,7 +46,6 @@ impl Transmutable for Multisig {
 impl Initializable for Multisig {
     #[inline(always)]
     fn is_initialized(&self) -> Result<bool, ProgramError> {
-        // is_initialized
         match self.is_initialized {
             0 => Ok(false),
             1 => Ok(true),

--- a/interface/src/state/multisig.rs
+++ b/interface/src/state/multisig.rs
@@ -46,6 +46,7 @@ impl Transmutable for Multisig {
 impl Initializable for Multisig {
     #[inline(always)]
     fn is_initialized(&self) -> Result<bool, ProgramError> {
+        // is_initialized
         match self.is_initialized {
             0 => Ok(false),
             1 => Ok(true),

--- a/p-token/Cargo.toml
+++ b/p-token/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib"]
 logging = []
 
 [dependencies]
-pinocchio = "0.8"
+pinocchio = "0.8.4"
 pinocchio-log = { version = "0.4", default-features = false }
 spl-token-interface = { version = "^0", path = "../interface" }
 

--- a/p-token/src/entrypoint.rs
+++ b/p-token/src/entrypoint.rs
@@ -194,7 +194,7 @@ fn inner_process_remaining_instruction(
             #[cfg(feature = "logging")]
             pinocchio::msg!("Instruction: Revoke");
 
-            process_revoke(accounts, instruction_data)
+            process_revoke(accounts)
         }
         // 6 - SetAuthority
         6 => {

--- a/p-token/src/entrypoint.rs
+++ b/p-token/src/entrypoint.rs
@@ -36,7 +36,7 @@ pub fn process_instruction(
     instruction_data: &[u8],
 ) -> ProgramResult {
     let [discriminator, remaining @ ..] = instruction_data else {
-        return Err(ProgramError::InvalidInstructionData);
+        return Err(TokenError::InvalidInstruction.into());
     };
 
     let result = if *discriminator == 255 {
@@ -78,7 +78,7 @@ pub(crate) fn inner_process_instruction(
     instruction_data: &[u8],
 ) -> ProgramResult {
     let [discriminator, instruction_data @ ..] = instruction_data else {
-        return Err(ProgramError::InvalidInstructionData);
+        return Err(TokenError::InvalidInstruction.into());
     };
 
     match *discriminator {
@@ -280,6 +280,6 @@ fn inner_process_remaining_instruction(
 
             process_withdraw_excess_lamports(accounts)
         }
-        _ => Err(ProgramError::InvalidInstructionData),
+        _ => Err(TokenError::InvalidInstruction.into()),
     }
 }

--- a/p-token/src/processor/amount_to_ui_amount.rs
+++ b/p-token/src/processor/amount_to_ui_amount.rs
@@ -19,7 +19,7 @@ pub fn process_amount_to_ui_amount(
     let amount = u64::from_le_bytes(
         instruction_data
             .try_into()
-            .map_err(|_error| ProgramError::InvalidInstructionData)?,
+            .map_err(|_error| TokenError::InvalidInstruction)?,
     );
 
     let mint_info = accounts.first().ok_or(ProgramError::NotEnoughAccountKeys)?;

--- a/p-token/src/processor/amount_to_ui_amount.rs
+++ b/p-token/src/processor/amount_to_ui_amount.rs
@@ -1,5 +1,5 @@
 use {
-    super::{check_account_owner, MAX_FORMATTED_DIGITS, U64_BYTES},
+    super::{check_account_owner, unpack_amount, MAX_FORMATTED_DIGITS},
     core::str::from_utf8_unchecked,
     pinocchio::{
         account_info::AccountInfo, program::set_return_data, program_error::ProgramError,
@@ -16,12 +16,7 @@ pub fn process_amount_to_ui_amount(
     accounts: &[AccountInfo],
     instruction_data: &[u8],
 ) -> ProgramResult {
-    let amount = if instruction_data.len() >= U64_BYTES {
-        // SAFETY: The minimum size of the instruction data is `U64_BYTES` bytes.
-        unsafe { u64::from_le_bytes(*(instruction_data.as_ptr() as *const [u8; U64_BYTES])) }
-    } else {
-        return Err(TokenError::InvalidInstruction.into());
-    };
+    let amount = unpack_amount(instruction_data)?;
 
     let mint_info = accounts.first().ok_or(ProgramError::NotEnoughAccountKeys)?;
     check_account_owner(mint_info)?;

--- a/p-token/src/processor/amount_to_ui_amount.rs
+++ b/p-token/src/processor/amount_to_ui_amount.rs
@@ -1,5 +1,5 @@
 use {
-    super::{check_account_owner, MAX_FORMATTED_DIGITS},
+    super::{check_account_owner, MAX_FORMATTED_DIGITS, U64_BYTES},
     core::str::from_utf8_unchecked,
     pinocchio::{
         account_info::AccountInfo, program::set_return_data, program_error::ProgramError,
@@ -16,11 +16,12 @@ pub fn process_amount_to_ui_amount(
     accounts: &[AccountInfo],
     instruction_data: &[u8],
 ) -> ProgramResult {
-    let amount = u64::from_le_bytes(
-        instruction_data
-            .try_into()
-            .map_err(|_error| TokenError::InvalidInstruction)?,
-    );
+    let amount = if instruction_data.len() >= U64_BYTES {
+        // SAFETY: The minimum size of the instruction data is `U64_BYTES` bytes.
+        unsafe { u64::from_le_bytes(*(instruction_data.as_ptr() as *const [u8; U64_BYTES])) }
+    } else {
+        return Err(TokenError::InvalidInstruction.into());
+    };
 
     let mint_info = accounts.first().ok_or(ProgramError::NotEnoughAccountKeys)?;
     check_account_owner(mint_info)?;

--- a/p-token/src/processor/approve.rs
+++ b/p-token/src/processor/approve.rs
@@ -1,17 +1,11 @@
 use {
-    super::{shared, U64_BYTES},
+    super::{shared, unpack_amount},
     pinocchio::{account_info::AccountInfo, ProgramResult},
-    spl_token_interface::error::TokenError,
 };
 
 #[inline(always)]
 pub fn process_approve(accounts: &[AccountInfo], instruction_data: &[u8]) -> ProgramResult {
-    let amount = if instruction_data.len() >= U64_BYTES {
-        // SAFETY: The minimum size of the instruction data is `U64_BYTES` bytes.
-        unsafe { u64::from_le_bytes(*(instruction_data.as_ptr() as *const [u8; U64_BYTES])) }
-    } else {
-        return Err(TokenError::InvalidInstruction.into());
-    };
+    let amount = unpack_amount(instruction_data)?;
 
     shared::approve::process_approve(accounts, amount, None)
 }

--- a/p-token/src/processor/approve.rs
+++ b/p-token/src/processor/approve.rs
@@ -1,6 +1,7 @@
 use {
     super::shared,
-    pinocchio::{account_info::AccountInfo, program_error::ProgramError, ProgramResult},
+    pinocchio::{account_info::AccountInfo, ProgramResult},
+    spl_token_interface::error::TokenError,
 };
 
 #[inline(always)]
@@ -8,7 +9,7 @@ pub fn process_approve(accounts: &[AccountInfo], instruction_data: &[u8]) -> Pro
     let amount = u64::from_le_bytes(
         instruction_data
             .try_into()
-            .map_err(|_error| ProgramError::InvalidInstructionData)?,
+            .map_err(|_error| TokenError::InvalidInstruction)?,
     );
 
     shared::approve::process_approve(accounts, amount, None)

--- a/p-token/src/processor/approve_checked.rs
+++ b/p-token/src/processor/approve_checked.rs
@@ -1,5 +1,5 @@
 use {
-    super::shared,
+    super::{shared, U64_BYTES},
     pinocchio::{account_info::AccountInfo, ProgramResult},
     spl_token_interface::error::TokenError,
 };
@@ -8,9 +8,10 @@ use {
 pub fn process_approve_checked(accounts: &[AccountInfo], instruction_data: &[u8]) -> ProgramResult {
     // expected u64 (8) + u8 (1)
     let (amount, decimals) = if instruction_data.len() == 9 {
-        let (amount, decimals) = instruction_data.split_at(core::mem::size_of::<u64>());
+        let (amount, decimals) = instruction_data.split_at(U64_BYTES);
         (
-            u64::from_le_bytes(amount.try_into().unwrap()),
+            // SAFETY: The size of `amount` is `U64_BYTES` bytes.
+            unsafe { u64::from_le_bytes(*(amount.as_ptr() as *const [u8; U64_BYTES])) },
             decimals.first().copied(),
         )
     } else {

--- a/p-token/src/processor/approve_checked.rs
+++ b/p-token/src/processor/approve_checked.rs
@@ -1,22 +1,11 @@
 use {
-    super::{shared, U64_BYTES},
+    super::{shared, unpack_amount_and_decimals},
     pinocchio::{account_info::AccountInfo, ProgramResult},
-    spl_token_interface::error::TokenError,
 };
 
 #[inline(always)]
 pub fn process_approve_checked(accounts: &[AccountInfo], instruction_data: &[u8]) -> ProgramResult {
-    // expected u64 (8) + u8 (1)
-    let (amount, decimals) = if instruction_data.len() >= 9 {
-        let (amount, decimals) = instruction_data.split_at(U64_BYTES);
-        (
-            // SAFETY: The size of `amount` is `U64_BYTES` bytes.
-            unsafe { u64::from_le_bytes(*(amount.as_ptr() as *const [u8; U64_BYTES])) },
-            decimals.first().copied(),
-        )
-    } else {
-        return Err(TokenError::InvalidInstruction.into());
-    };
+    let (amount, decimals) = unpack_amount_and_decimals(instruction_data)?;
 
-    shared::approve::process_approve(accounts, amount, decimals)
+    shared::approve::process_approve(accounts, amount, Some(decimals))
 }

--- a/p-token/src/processor/approve_checked.rs
+++ b/p-token/src/processor/approve_checked.rs
@@ -1,6 +1,7 @@
 use {
     super::shared,
-    pinocchio::{account_info::AccountInfo, program_error::ProgramError, ProgramResult},
+    pinocchio::{account_info::AccountInfo, ProgramResult},
+    spl_token_interface::error::TokenError,
 };
 
 #[inline(always)]
@@ -13,7 +14,7 @@ pub fn process_approve_checked(accounts: &[AccountInfo], instruction_data: &[u8]
             decimals.first().copied(),
         )
     } else {
-        return Err(ProgramError::InvalidInstructionData);
+        return Err(TokenError::InvalidInstruction.into());
     };
 
     shared::approve::process_approve(accounts, amount, decimals)

--- a/p-token/src/processor/approve_checked.rs
+++ b/p-token/src/processor/approve_checked.rs
@@ -7,7 +7,7 @@ use {
 #[inline(always)]
 pub fn process_approve_checked(accounts: &[AccountInfo], instruction_data: &[u8]) -> ProgramResult {
     // expected u64 (8) + u8 (1)
-    let (amount, decimals) = if instruction_data.len() == 9 {
+    let (amount, decimals) = if instruction_data.len() >= 9 {
         let (amount, decimals) = instruction_data.split_at(U64_BYTES);
         (
             // SAFETY: The size of `amount` is `U64_BYTES` bytes.

--- a/p-token/src/processor/batch.rs
+++ b/p-token/src/processor/batch.rs
@@ -1,6 +1,7 @@
 use {
     crate::entrypoint::inner_process_instruction,
     pinocchio::{account_info::AccountInfo, program_error::ProgramError, ProgramResult},
+    spl_token_interface::error::TokenError,
 };
 
 /// The size of the batch instruction header.
@@ -17,7 +18,7 @@ pub fn process_batch(mut accounts: &[AccountInfo], mut instruction_data: &[u8]) 
 
         if instruction_data.len() < IX_HEADER_SIZE {
             // The instruction data must have at least two bytes.
-            return Err(ProgramError::InvalidInstructionData);
+            return Err(TokenError::InvalidInstruction.into());
         }
 
         // SAFETY: The instruction data is guaranteed to have at least two bytes
@@ -27,7 +28,7 @@ pub fn process_batch(mut accounts: &[AccountInfo], mut instruction_data: &[u8]) 
         let data_offset = IX_HEADER_SIZE + unsafe { *instruction_data.get_unchecked(1) as usize };
 
         if instruction_data.len() < data_offset || data_offset == IX_HEADER_SIZE {
-            return Err(ProgramError::InvalidInstructionData);
+            return Err(TokenError::InvalidInstruction.into());
         }
 
         if accounts.len() < expected_accounts {

--- a/p-token/src/processor/burn.rs
+++ b/p-token/src/processor/burn.rs
@@ -1,17 +1,11 @@
 use {
-    super::{shared, U64_BYTES},
+    super::{shared, unpack_amount},
     pinocchio::{account_info::AccountInfo, ProgramResult},
-    spl_token_interface::error::TokenError,
 };
 
 #[inline(always)]
 pub fn process_burn(accounts: &[AccountInfo], instruction_data: &[u8]) -> ProgramResult {
-    let amount = if instruction_data.len() >= U64_BYTES {
-        // SAFETY: The minimum size of the instruction data is `U64_BYTES` bytes.
-        unsafe { u64::from_le_bytes(*(instruction_data.as_ptr() as *const [u8; U64_BYTES])) }
-    } else {
-        return Err(TokenError::InvalidInstruction.into());
-    };
+    let amount = unpack_amount(instruction_data)?;
 
     shared::burn::process_burn(accounts, amount, None)
 }

--- a/p-token/src/processor/burn.rs
+++ b/p-token/src/processor/burn.rs
@@ -1,6 +1,7 @@
 use {
     super::shared,
-    pinocchio::{account_info::AccountInfo, program_error::ProgramError, ProgramResult},
+    pinocchio::{account_info::AccountInfo, ProgramResult},
+    spl_token_interface::error::TokenError,
 };
 
 #[inline(always)]
@@ -8,7 +9,7 @@ pub fn process_burn(accounts: &[AccountInfo], instruction_data: &[u8]) -> Progra
     let amount = u64::from_le_bytes(
         instruction_data
             .try_into()
-            .map_err(|_error| ProgramError::InvalidInstructionData)?,
+            .map_err(|_error| TokenError::InvalidInstruction)?,
     );
 
     shared::burn::process_burn(accounts, amount, None)

--- a/p-token/src/processor/burn.rs
+++ b/p-token/src/processor/burn.rs
@@ -1,16 +1,17 @@
 use {
-    super::shared,
+    super::{shared, U64_BYTES},
     pinocchio::{account_info::AccountInfo, ProgramResult},
     spl_token_interface::error::TokenError,
 };
 
 #[inline(always)]
 pub fn process_burn(accounts: &[AccountInfo], instruction_data: &[u8]) -> ProgramResult {
-    let amount = u64::from_le_bytes(
-        instruction_data
-            .try_into()
-            .map_err(|_error| TokenError::InvalidInstruction)?,
-    );
+    let amount = if instruction_data.len() >= U64_BYTES {
+        // SAFETY: The minimum size of the instruction data is `U64_BYTES` bytes.
+        unsafe { u64::from_le_bytes(*(instruction_data.as_ptr() as *const [u8; U64_BYTES])) }
+    } else {
+        return Err(TokenError::InvalidInstruction.into());
+    };
 
     shared::burn::process_burn(accounts, amount, None)
 }

--- a/p-token/src/processor/burn_checked.rs
+++ b/p-token/src/processor/burn_checked.rs
@@ -1,6 +1,7 @@
 use {
     super::shared,
-    pinocchio::{account_info::AccountInfo, program_error::ProgramError, ProgramResult},
+    pinocchio::{account_info::AccountInfo, ProgramResult},
+    spl_token_interface::error::TokenError,
 };
 
 #[inline(always)]
@@ -13,7 +14,7 @@ pub fn process_burn_checked(accounts: &[AccountInfo], instruction_data: &[u8]) -
             decimals.first().copied(),
         )
     } else {
-        return Err(ProgramError::InvalidInstructionData);
+        return Err(TokenError::InvalidInstruction.into());
     };
 
     shared::burn::process_burn(accounts, amount, decimals)

--- a/p-token/src/processor/burn_checked.rs
+++ b/p-token/src/processor/burn_checked.rs
@@ -1,5 +1,5 @@
 use {
-    super::shared,
+    super::{shared, U64_BYTES},
     pinocchio::{account_info::AccountInfo, ProgramResult},
     spl_token_interface::error::TokenError,
 };
@@ -8,9 +8,10 @@ use {
 pub fn process_burn_checked(accounts: &[AccountInfo], instruction_data: &[u8]) -> ProgramResult {
     // expected u64 (8) + u8 (1)
     let (amount, decimals) = if instruction_data.len() == 9 {
-        let (amount, decimals) = instruction_data.split_at(core::mem::size_of::<u64>());
+        let (amount, decimals) = instruction_data.split_at(U64_BYTES);
         (
-            u64::from_le_bytes(amount.try_into().unwrap()),
+            // SAFETY: The size of `amount` is `U64_BYTES` bytes.
+            unsafe { u64::from_le_bytes(*(amount.as_ptr() as *const [u8; U64_BYTES])) },
             decimals.first().copied(),
         )
     } else {

--- a/p-token/src/processor/burn_checked.rs
+++ b/p-token/src/processor/burn_checked.rs
@@ -1,22 +1,11 @@
 use {
-    super::{shared, U64_BYTES},
+    super::{shared, unpack_amount_and_decimals},
     pinocchio::{account_info::AccountInfo, ProgramResult},
-    spl_token_interface::error::TokenError,
 };
 
 #[inline(always)]
 pub fn process_burn_checked(accounts: &[AccountInfo], instruction_data: &[u8]) -> ProgramResult {
-    // expected u64 (8) + u8 (1)
-    let (amount, decimals) = if instruction_data.len() >= 9 {
-        let (amount, decimals) = instruction_data.split_at(U64_BYTES);
-        (
-            // SAFETY: The size of `amount` is `U64_BYTES` bytes.
-            unsafe { u64::from_le_bytes(*(amount.as_ptr() as *const [u8; U64_BYTES])) },
-            decimals.first().copied(),
-        )
-    } else {
-        return Err(TokenError::InvalidInstruction.into());
-    };
+    let (amount, decimals) = unpack_amount_and_decimals(instruction_data)?;
 
-    shared::burn::process_burn(accounts, amount, decimals)
+    shared::burn::process_burn(accounts, amount, Some(decimals))
 }

--- a/p-token/src/processor/burn_checked.rs
+++ b/p-token/src/processor/burn_checked.rs
@@ -7,7 +7,7 @@ use {
 #[inline(always)]
 pub fn process_burn_checked(accounts: &[AccountInfo], instruction_data: &[u8]) -> ProgramResult {
     // expected u64 (8) + u8 (1)
-    let (amount, decimals) = if instruction_data.len() == 9 {
+    let (amount, decimals) = if instruction_data.len() >= 9 {
         let (amount, decimals) = instruction_data.split_at(U64_BYTES);
         (
             // SAFETY: The size of `amount` is `U64_BYTES` bytes.

--- a/p-token/src/processor/close_account.rs
+++ b/p-token/src/processor/close_account.rs
@@ -33,7 +33,7 @@ pub fn process_close_account(accounts: &[AccountInfo]) -> ProgramResult {
         }
 
         let authority = source_account
-            .close_authority()
+            .close_authority()?
             .unwrap_or(&source_account.owner);
 
         if !source_account.is_owned_by_system_program_or_incinerator() {

--- a/p-token/src/processor/close_account.rs
+++ b/p-token/src/processor/close_account.rs
@@ -33,7 +33,7 @@ pub fn process_close_account(accounts: &[AccountInfo]) -> ProgramResult {
         }
 
         let authority = source_account
-            .close_authority()?
+            .close_authority()
             .unwrap_or(&source_account.owner);
 
         if !source_account.is_owned_by_system_program_or_incinerator() {

--- a/p-token/src/processor/initialize_account2.rs
+++ b/p-token/src/processor/initialize_account2.rs
@@ -1,8 +1,7 @@
 use {
     super::shared,
-    pinocchio::{
-        account_info::AccountInfo, program_error::ProgramError, pubkey::Pubkey, ProgramResult,
-    },
+    pinocchio::{account_info::AccountInfo, pubkey::Pubkey, ProgramResult},
+    spl_token_interface::error::TokenError,
 };
 
 #[inline(always)]
@@ -12,7 +11,7 @@ pub fn process_initialize_account2(
 ) -> ProgramResult {
     let owner: &Pubkey = instruction_data
         .try_into()
-        .map_err(|_error| ProgramError::InvalidInstructionData)?;
+        .map_err(|_error| TokenError::InvalidInstruction)?;
 
     shared::initialize_account::process_initialize_account(accounts, Some(owner), true)
 }

--- a/p-token/src/processor/initialize_account2.rs
+++ b/p-token/src/processor/initialize_account2.rs
@@ -1,6 +1,10 @@
 use {
     super::shared,
-    pinocchio::{account_info::AccountInfo, pubkey::Pubkey, ProgramResult},
+    pinocchio::{
+        account_info::AccountInfo,
+        pubkey::{Pubkey, PUBKEY_BYTES},
+        ProgramResult,
+    },
     spl_token_interface::error::TokenError,
 };
 
@@ -9,9 +13,12 @@ pub fn process_initialize_account2(
     accounts: &[AccountInfo],
     instruction_data: &[u8],
 ) -> ProgramResult {
-    let owner: &Pubkey = instruction_data
-        .try_into()
-        .map_err(|_error| TokenError::InvalidInstruction)?;
+    let owner = if instruction_data.len() >= PUBKEY_BYTES {
+        // SAFETY: The minimum size of the instruction data is `PUBKEY_BYTES` bytes.
+        unsafe { &*(instruction_data.as_ptr() as *const Pubkey) }
+    } else {
+        return Err(TokenError::InvalidInstruction.into());
+    };
 
     shared::initialize_account::process_initialize_account(accounts, Some(owner), true)
 }

--- a/p-token/src/processor/initialize_account3.rs
+++ b/p-token/src/processor/initialize_account3.rs
@@ -1,8 +1,7 @@
 use {
     super::shared,
-    pinocchio::{
-        account_info::AccountInfo, program_error::ProgramError, pubkey::Pubkey, ProgramResult,
-    },
+    pinocchio::{account_info::AccountInfo, pubkey::Pubkey, ProgramResult},
+    spl_token_interface::error::TokenError,
 };
 
 #[inline(always)]
@@ -12,7 +11,7 @@ pub fn process_initialize_account3(
 ) -> ProgramResult {
     let owner: &Pubkey = instruction_data
         .try_into()
-        .map_err(|_error| ProgramError::InvalidInstructionData)?;
+        .map_err(|_error| TokenError::InvalidInstruction)?;
 
     shared::initialize_account::process_initialize_account(accounts, Some(owner), false)
 }

--- a/p-token/src/processor/initialize_account3.rs
+++ b/p-token/src/processor/initialize_account3.rs
@@ -1,6 +1,10 @@
 use {
     super::shared,
-    pinocchio::{account_info::AccountInfo, pubkey::Pubkey, ProgramResult},
+    pinocchio::{
+        account_info::AccountInfo,
+        pubkey::{Pubkey, PUBKEY_BYTES},
+        ProgramResult,
+    },
     spl_token_interface::error::TokenError,
 };
 
@@ -9,9 +13,12 @@ pub fn process_initialize_account3(
     accounts: &[AccountInfo],
     instruction_data: &[u8],
 ) -> ProgramResult {
-    let owner: &Pubkey = instruction_data
-        .try_into()
-        .map_err(|_error| TokenError::InvalidInstruction)?;
+    let owner = if instruction_data.len() >= PUBKEY_BYTES {
+        // SAFETY: The minimum size of the instruction data is `PUBKEY_BYTES` bytes.
+        unsafe { &*(instruction_data.as_ptr() as *const Pubkey) }
+    } else {
+        return Err(TokenError::InvalidInstruction.into());
+    };
 
     shared::initialize_account::process_initialize_account(accounts, Some(owner), false)
 }

--- a/p-token/src/processor/initialize_immutable_owner.rs
+++ b/p-token/src/processor/initialize_immutable_owner.rs
@@ -13,7 +13,7 @@ pub fn process_initialize_immutable_owner(accounts: &[AccountInfo]) -> ProgramRe
     // SAFETY: single immutable borrow to `token_account_info` account data.
     let account = unsafe { load_unchecked::<Account>(token_account_info.borrow_data_unchecked())? };
 
-    if account.is_initialized() {
+    if account.is_initialized()? {
         return Err(TokenError::AlreadyInUse.into());
     }
     // Please upgrade to SPL Token 2022 for immutable owner support.

--- a/p-token/src/processor/initialize_multisig.rs
+++ b/p-token/src/processor/initialize_multisig.rs
@@ -1,6 +1,7 @@
 use {
     super::shared,
-    pinocchio::{account_info::AccountInfo, program_error::ProgramError, ProgramResult},
+    pinocchio::{account_info::AccountInfo, ProgramResult},
+    spl_token_interface::error::TokenError,
 };
 
 #[inline(always)]
@@ -10,7 +11,7 @@ pub fn process_initialize_multisig(
 ) -> ProgramResult {
     let m = instruction_data
         .first()
-        .ok_or(ProgramError::InvalidInstructionData)?;
+        .ok_or(TokenError::InvalidInstruction)?;
 
     shared::initialize_multisig::process_initialize_multisig(accounts, *m, true)
 }

--- a/p-token/src/processor/initialize_multisig2.rs
+++ b/p-token/src/processor/initialize_multisig2.rs
@@ -1,6 +1,7 @@
 use {
     super::shared,
-    pinocchio::{account_info::AccountInfo, program_error::ProgramError, ProgramResult},
+    pinocchio::{account_info::AccountInfo, ProgramResult},
+    spl_token_interface::error::TokenError,
 };
 
 pub fn process_initialize_multisig2(
@@ -9,6 +10,6 @@ pub fn process_initialize_multisig2(
 ) -> ProgramResult {
     let m = instruction_data
         .first()
-        .ok_or(ProgramError::InvalidInstructionData)?;
+        .ok_or(TokenError::InvalidInstruction)?;
     shared::initialize_multisig::process_initialize_multisig(accounts, *m, false)
 }

--- a/p-token/src/processor/initialize_multisig2.rs
+++ b/p-token/src/processor/initialize_multisig2.rs
@@ -11,5 +11,6 @@ pub fn process_initialize_multisig2(
     let m = instruction_data
         .first()
         .ok_or(TokenError::InvalidInstruction)?;
+
     shared::initialize_multisig::process_initialize_multisig(accounts, *m, false)
 }

--- a/p-token/src/processor/mint_to.rs
+++ b/p-token/src/processor/mint_to.rs
@@ -1,16 +1,17 @@
 use {
-    super::shared,
+    super::{shared, U64_BYTES},
     pinocchio::{account_info::AccountInfo, ProgramResult},
     spl_token_interface::error::TokenError,
 };
 
 #[inline(always)]
 pub fn process_mint_to(accounts: &[AccountInfo], instruction_data: &[u8]) -> ProgramResult {
-    let amount = u64::from_le_bytes(
-        instruction_data
-            .try_into()
-            .map_err(|_error| TokenError::InvalidInstruction)?,
-    );
+    let amount = if instruction_data.len() >= U64_BYTES {
+        // SAFETY: The minimum size of the instruction data is `U64_BYTES` bytes.
+        unsafe { u64::from_le_bytes(*(instruction_data.as_ptr() as *const [u8; U64_BYTES])) }
+    } else {
+        return Err(TokenError::InvalidInstruction.into());
+    };
 
     shared::mint_to::process_mint_to(accounts, amount, None)
 }

--- a/p-token/src/processor/mint_to.rs
+++ b/p-token/src/processor/mint_to.rs
@@ -1,6 +1,7 @@
 use {
     super::shared,
-    pinocchio::{account_info::AccountInfo, program_error::ProgramError, ProgramResult},
+    pinocchio::{account_info::AccountInfo, ProgramResult},
+    spl_token_interface::error::TokenError,
 };
 
 #[inline(always)]
@@ -8,7 +9,7 @@ pub fn process_mint_to(accounts: &[AccountInfo], instruction_data: &[u8]) -> Pro
     let amount = u64::from_le_bytes(
         instruction_data
             .try_into()
-            .map_err(|_error| ProgramError::InvalidInstructionData)?,
+            .map_err(|_error| TokenError::InvalidInstruction)?,
     );
 
     shared::mint_to::process_mint_to(accounts, amount, None)

--- a/p-token/src/processor/mint_to.rs
+++ b/p-token/src/processor/mint_to.rs
@@ -1,17 +1,11 @@
 use {
-    super::{shared, U64_BYTES},
+    super::{shared, unpack_amount},
     pinocchio::{account_info::AccountInfo, ProgramResult},
-    spl_token_interface::error::TokenError,
 };
 
 #[inline(always)]
 pub fn process_mint_to(accounts: &[AccountInfo], instruction_data: &[u8]) -> ProgramResult {
-    let amount = if instruction_data.len() >= U64_BYTES {
-        // SAFETY: The minimum size of the instruction data is `U64_BYTES` bytes.
-        unsafe { u64::from_le_bytes(*(instruction_data.as_ptr() as *const [u8; U64_BYTES])) }
-    } else {
-        return Err(TokenError::InvalidInstruction.into());
-    };
+    let amount = unpack_amount(instruction_data)?;
 
     shared::mint_to::process_mint_to(accounts, amount, None)
 }

--- a/p-token/src/processor/mint_to_checked.rs
+++ b/p-token/src/processor/mint_to_checked.rs
@@ -7,7 +7,7 @@ use {
 #[inline(always)]
 pub fn process_mint_to_checked(accounts: &[AccountInfo], instruction_data: &[u8]) -> ProgramResult {
     // expected u64 (8) + u8 (1)
-    let (amount, decimals) = if instruction_data.len() == 9 {
+    let (amount, decimals) = if instruction_data.len() >= 9 {
         let (amount, decimals) = instruction_data.split_at(U64_BYTES);
         (
             // SAFETY: The size of `amount` is `U64_BYTES` bytes.

--- a/p-token/src/processor/mint_to_checked.rs
+++ b/p-token/src/processor/mint_to_checked.rs
@@ -1,5 +1,5 @@
 use {
-    super::shared,
+    super::{shared, U64_BYTES},
     pinocchio::{account_info::AccountInfo, ProgramResult},
     spl_token_interface::error::TokenError,
 };
@@ -8,9 +8,10 @@ use {
 pub fn process_mint_to_checked(accounts: &[AccountInfo], instruction_data: &[u8]) -> ProgramResult {
     // expected u64 (8) + u8 (1)
     let (amount, decimals) = if instruction_data.len() == 9 {
-        let (amount, decimals) = instruction_data.split_at(core::mem::size_of::<u64>());
+        let (amount, decimals) = instruction_data.split_at(U64_BYTES);
         (
-            u64::from_le_bytes(amount.try_into().unwrap()),
+            // SAFETY: The size of `amount` is `U64_BYTES` bytes.
+            unsafe { u64::from_le_bytes(*(amount.as_ptr() as *const [u8; U64_BYTES])) },
             decimals.first().copied(),
         )
     } else {

--- a/p-token/src/processor/mint_to_checked.rs
+++ b/p-token/src/processor/mint_to_checked.rs
@@ -1,6 +1,7 @@
 use {
     super::shared,
-    pinocchio::{account_info::AccountInfo, program_error::ProgramError, ProgramResult},
+    pinocchio::{account_info::AccountInfo, ProgramResult},
+    spl_token_interface::error::TokenError,
 };
 
 #[inline(always)]
@@ -13,7 +14,7 @@ pub fn process_mint_to_checked(accounts: &[AccountInfo], instruction_data: &[u8]
             decimals.first().copied(),
         )
     } else {
-        return Err(ProgramError::InvalidInstructionData);
+        return Err(TokenError::InvalidInstruction.into());
     };
 
     shared::mint_to::process_mint_to(accounts, amount, decimals)

--- a/p-token/src/processor/mint_to_checked.rs
+++ b/p-token/src/processor/mint_to_checked.rs
@@ -1,22 +1,11 @@
 use {
-    super::{shared, U64_BYTES},
+    super::{shared, unpack_amount_and_decimals},
     pinocchio::{account_info::AccountInfo, ProgramResult},
-    spl_token_interface::error::TokenError,
 };
 
 #[inline(always)]
 pub fn process_mint_to_checked(accounts: &[AccountInfo], instruction_data: &[u8]) -> ProgramResult {
-    // expected u64 (8) + u8 (1)
-    let (amount, decimals) = if instruction_data.len() >= 9 {
-        let (amount, decimals) = instruction_data.split_at(U64_BYTES);
-        (
-            // SAFETY: The size of `amount` is `U64_BYTES` bytes.
-            unsafe { u64::from_le_bytes(*(amount.as_ptr() as *const [u8; U64_BYTES])) },
-            decimals.first().copied(),
-        )
-    } else {
-        return Err(TokenError::InvalidInstruction.into());
-    };
+    let (amount, decimals) = unpack_amount_and_decimals(instruction_data)?;
 
-    shared::mint_to::process_mint_to(accounts, amount, decimals)
+    shared::mint_to::process_mint_to(accounts, amount, Some(decimals))
 }

--- a/p-token/src/processor/mod.rs
+++ b/p-token/src/processor/mod.rs
@@ -183,3 +183,31 @@ fn try_ui_amount_into_amount(ui_amount: &str, decimals: u8) -> Result<u64, Progr
             .map_err(|_| ProgramError::InvalidArgument)
     }
 }
+
+/// Unpacks a `u64` amount from the instruction data.
+#[inline(always)]
+const fn unpack_amount(instruction_data: &[u8]) -> Result<u64, TokenError> {
+    // expected u64 (8)
+    if instruction_data.len() >= U64_BYTES {
+        // SAFETY: The minimum size of the instruction data is `U64_BYTES` bytes.
+        Ok(unsafe { u64::from_le_bytes(*(instruction_data.as_ptr() as *const [u8; U64_BYTES])) })
+    } else {
+        Err(TokenError::InvalidInstruction)
+    }
+}
+
+/// Unpacks a `u64` amount and an optional `u8` from the instruction data.
+#[inline(always)]
+const fn unpack_amount_and_decimals(instruction_data: &[u8]) -> Result<(u64, u8), TokenError> {
+    // expected u64 (8) + u8 (1)
+    if instruction_data.len() >= 9 {
+        let (amount, decimals) = instruction_data.split_at(U64_BYTES);
+        Ok((
+            // SAFETY: The size of `amount` is `U64_BYTES` bytes.
+            unsafe { u64::from_le_bytes(*(amount.as_ptr() as *const [u8; U64_BYTES])) },
+            decimals[0],
+        ))
+    } else {
+        Err(TokenError::InvalidInstruction)
+    }
+}

--- a/p-token/src/processor/mod.rs
+++ b/p-token/src/processor/mod.rs
@@ -64,6 +64,9 @@ pub use {
     withdraw_excess_lamports::process_withdraw_excess_lamports,
 };
 
+/// Number of bytes in a `u64`.
+const U64_BYTES: usize = core::mem::size_of::<u64>();
+
 /// Maximum number of digits in a formatted `u64`.
 ///
 /// The maximum number of digits is equal to the maximum number

--- a/p-token/src/processor/revoke.rs
+++ b/p-token/src/processor/revoke.rs
@@ -8,7 +8,7 @@ use {
 };
 
 #[inline(always)]
-pub fn process_revoke(accounts: &[AccountInfo], _instruction_data: &[u8]) -> ProgramResult {
+pub fn process_revoke(accounts: &[AccountInfo]) -> ProgramResult {
     let [source_account_info, owner_info, remaining @ ..] = accounts else {
         return Err(ProgramError::NotEnoughAccountKeys);
     };

--- a/p-token/src/processor/revoke.rs
+++ b/p-token/src/processor/revoke.rs
@@ -9,7 +9,7 @@ use {
 
 #[inline(always)]
 pub fn process_revoke(accounts: &[AccountInfo]) -> ProgramResult {
-    let [source_account_info, owner_info, remaining @ ..] = accounts else {
+    let [source_account_info, remaining @ ..] = accounts else {
         return Err(ProgramError::NotEnoughAccountKeys);
     };
 
@@ -17,6 +17,12 @@ pub fn process_revoke(accounts: &[AccountInfo]) -> ProgramResult {
     // `load_mut` validates that the account is initialized.
     let source_account =
         unsafe { load_mut::<Account>(source_account_info.borrow_mut_data_unchecked())? };
+
+    // Unpacking the remaining accounts to get the owner account at this point
+    // to maintain the same order as SPL Token.
+    let [owner_info, remaining @ ..] = remaining else {
+        return Err(ProgramError::NotEnoughAccountKeys);
+    };
 
     if source_account.is_frozen()? {
         return Err(TokenError::AccountFrozen.into());

--- a/p-token/src/processor/revoke.rs
+++ b/p-token/src/processor/revoke.rs
@@ -18,7 +18,7 @@ pub fn process_revoke(accounts: &[AccountInfo], _instruction_data: &[u8]) -> Pro
     let source_account =
         unsafe { load_mut::<Account>(source_account_info.borrow_mut_data_unchecked())? };
 
-    if source_account.is_frozen() {
+    if source_account.is_frozen()? {
         return Err(TokenError::AccountFrozen.into());
     }
 

--- a/p-token/src/processor/set_authority.rs
+++ b/p-token/src/processor/set_authority.rs
@@ -64,7 +64,7 @@ pub fn process_set_authority(accounts: &[AccountInfo], instruction_data: &[u8]) 
                 }
             }
             AuthorityType::CloseAccount => {
-                let authority = account.close_authority()?.unwrap_or(&account.owner);
+                let authority = account.close_authority().unwrap_or(&account.owner);
                 validate_owner(authority, authority_info, remaining)?;
 
                 if let Some(authority) = new_authority {
@@ -86,7 +86,7 @@ pub fn process_set_authority(accounts: &[AccountInfo], instruction_data: &[u8]) 
             AuthorityType::MintTokens => {
                 // Once a mint's supply is fixed, it cannot be undone by setting a new
                 // mint_authority.
-                let mint_authority = mint.mint_authority()?.ok_or(TokenError::FixedSupply)?;
+                let mint_authority = mint.mint_authority().ok_or(TokenError::FixedSupply)?;
 
                 validate_owner(mint_authority, authority_info, remaining)?;
 
@@ -100,7 +100,7 @@ pub fn process_set_authority(accounts: &[AccountInfo], instruction_data: &[u8]) 
                 // Once a mint's freeze authority is disabled, it cannot be re-enabled by
                 // setting a new freeze_authority.
                 let freeze_authority = mint
-                    .freeze_authority()?
+                    .freeze_authority()
                     .ok_or(TokenError::MintCannotFreeze)?;
 
                 validate_owner(freeze_authority, authority_info, remaining)?;

--- a/p-token/src/processor/set_authority.rs
+++ b/p-token/src/processor/set_authority.rs
@@ -14,21 +14,23 @@ use {
 pub fn process_set_authority(accounts: &[AccountInfo], instruction_data: &[u8]) -> ProgramResult {
     // Validates the instruction data.
 
-    // SAFETY: The expected size of the instruction data is either 2 or 34 bytes:
-    //   - authority_type (1 byte)
-    //   - option + new_authority (1 byte + 32 bytes)
-    let (authority_type, new_authority) = unsafe {
-        match instruction_data.len() {
-            2 if *instruction_data.get_unchecked(1) == 0 => (
-                AuthorityType::try_from(*instruction_data.get_unchecked(0))?,
-                None,
-            ),
-            34 if *instruction_data.get_unchecked(1) == 1 => (
-                AuthorityType::try_from(*instruction_data.get_unchecked(0))?,
-                Some(&*(instruction_data.as_ptr().add(2) as *const Pubkey)),
-            ),
-            _ => return Err(TokenError::InvalidInstruction.into()),
+    let (authority_type, new_authority) = if instruction_data.len() >= 2 {
+        // SAFETY: The expected size of the instruction data is either 2 or 34 bytes:
+        //   - authority_type (1 byte)
+        //   - option + new_authority (1 byte + 32 bytes)
+        unsafe {
+            let authority_type = AuthorityType::try_from(*instruction_data.get_unchecked(0))?;
+            let new_authority = if *instruction_data.get_unchecked(1) == 0 {
+                None
+            } else if *instruction_data.get_unchecked(1) == 1 && instruction_data.len() >= 34 {
+                Some(&*(instruction_data.as_ptr().add(2) as *const Pubkey))
+            } else {
+                return Err(TokenError::InvalidInstruction.into());
+            };
+            (authority_type, new_authority)
         }
+    } else {
+        return Err(TokenError::InvalidInstruction.into());
     };
 
     // Validates the accounts.

--- a/p-token/src/processor/shared/approve.rs
+++ b/p-token/src/processor/shared/approve.rs
@@ -51,7 +51,7 @@ pub fn process_approve(
     let source_account =
         unsafe { load_mut::<Account>(source_account_info.borrow_mut_data_unchecked())? };
 
-    if source_account.is_frozen() {
+    if source_account.is_frozen()? {
         return Err(TokenError::AccountFrozen.into());
     }
 

--- a/p-token/src/processor/shared/burn.rs
+++ b/p-token/src/processor/shared/burn.rs
@@ -53,7 +53,7 @@ pub fn process_burn(
     }
 
     if !source_account.is_owned_by_system_program_or_incinerator() {
-        match source_account.delegate()? {
+        match source_account.delegate() {
             Some(delegate) if authority_info.key() == delegate => {
                 validate_owner(delegate, authority_info, remaining)?;
 

--- a/p-token/src/processor/shared/burn.rs
+++ b/p-token/src/processor/shared/burn.rs
@@ -21,6 +21,11 @@ pub fn process_burn(
     // `load_mut` validates that the account is initialized.
     let source_account =
         unsafe { load_mut::<Account>(source_account_info.borrow_mut_data_unchecked())? };
+    // SAFETY: single mutable borrow to `mint_info` account data and
+    // `load_mut` validates that the mint is initialized; additionally, an
+    // account cannot be both a token account and a mint, so if duplicates are
+    // passed in, one of them will fail the `load_mut` check.
+    let mint = unsafe { load_mut::<Mint>(mint_info.borrow_mut_data_unchecked())? };
 
     if source_account.is_frozen()? {
         return Err(TokenError::AccountFrozen.into());
@@ -35,12 +40,6 @@ pub fn process_burn(
         .amount()
         .checked_sub(amount)
         .ok_or(TokenError::InsufficientFunds)?;
-
-    // SAFETY: single mutable borrow to `mint_info` account data and
-    // `load_mut` validates that the mint is initialized; additionally, an
-    // account cannot be both a token account and a mint, so if duplicates are
-    // passed in, one of them will fail the `load_mut` check.
-    let mint = unsafe { load_mut::<Mint>(mint_info.borrow_mut_data_unchecked())? };
 
     if mint_info.key() != &source_account.mint {
         return Err(TokenError::MintMismatch.into());

--- a/p-token/src/processor/shared/burn.rs
+++ b/p-token/src/processor/shared/burn.rs
@@ -22,7 +22,7 @@ pub fn process_burn(
     let source_account =
         unsafe { load_mut::<Account>(source_account_info.borrow_mut_data_unchecked())? };
 
-    if source_account.is_frozen() {
+    if source_account.is_frozen()? {
         return Err(TokenError::AccountFrozen.into());
     }
     if source_account.is_native() {
@@ -53,7 +53,7 @@ pub fn process_burn(
     }
 
     if !source_account.is_owned_by_system_program_or_incinerator() {
-        match source_account.delegate() {
+        match source_account.delegate()? {
             Some(delegate) if authority_info.key() == delegate => {
                 validate_owner(delegate, authority_info, remaining)?;
 

--- a/p-token/src/processor/shared/initialize_account.rs
+++ b/p-token/src/processor/shared/initialize_account.rs
@@ -62,7 +62,7 @@ pub fn process_initialize_account(
     let account =
         unsafe { load_mut_unchecked::<Account>(new_account_info.borrow_mut_data_unchecked())? };
 
-    if account.is_initialized() {
+    if account.is_initialized()? {
         return Err(TokenError::AlreadyInUse.into());
     }
 
@@ -80,7 +80,7 @@ pub fn process_initialize_account(
         };
     }
 
-    account.state = AccountState::Initialized;
+    account.set_account_state(AccountState::Initialized);
     account.mint = *mint_info.key();
     account.owner = *owner;
 

--- a/p-token/src/processor/shared/initialize_mint.rs
+++ b/p-token/src/processor/shared/initialize_mint.rs
@@ -37,7 +37,7 @@ pub fn process_initialize_mint(
                 &*(instruction_data.as_ptr().add(1) as *const Pubkey),
                 Some(&*(instruction_data.as_ptr().add(34) as *const Pubkey)),
             ),
-            _ => return Err(ProgramError::InvalidInstructionData),
+            _ => return Err(TokenError::InvalidInstruction.into()),
         }
     };
 
@@ -58,7 +58,7 @@ pub fn process_initialize_mint(
     // SAFETY: single mutable borrow to `mint_info` account data.
     let mint = unsafe { load_mut_unchecked::<Mint>(mint_info.borrow_mut_data_unchecked())? };
 
-    if mint.is_initialized() {
+    if mint.is_initialized()? {
         return Err(TokenError::AlreadyInUse.into());
     }
 

--- a/p-token/src/processor/shared/initialize_multisig.rs
+++ b/p-token/src/processor/shared/initialize_multisig.rs
@@ -46,7 +46,7 @@ pub fn process_initialize_multisig(
     let multisig =
         unsafe { load_mut_unchecked::<Multisig>(multisig_info.borrow_mut_data_unchecked())? };
 
-    if multisig.is_initialized() {
+    if multisig.is_initialized()? {
         return Err(TokenError::AlreadyInUse.into());
     }
 

--- a/p-token/src/processor/shared/mint_to.rs
+++ b/p-token/src/processor/shared/mint_to.rs
@@ -47,7 +47,7 @@ pub fn process_mint_to(
         }
     }
 
-    match mint.mint_authority()? {
+    match mint.mint_authority() {
         Some(mint_authority) => validate_owner(mint_authority, owner_info, remaining)?,
         None => return Err(TokenError::FixedSupply.into()),
     }

--- a/p-token/src/processor/shared/mint_to.rs
+++ b/p-token/src/processor/shared/mint_to.rs
@@ -25,7 +25,7 @@ pub fn process_mint_to(
     let destination_account =
         unsafe { load_mut::<Account>(destination_account_info.borrow_mut_data_unchecked())? };
 
-    if destination_account.is_frozen() {
+    if destination_account.is_frozen()? {
         return Err(TokenError::AccountFrozen.into());
     }
 
@@ -47,7 +47,7 @@ pub fn process_mint_to(
         }
     }
 
-    match mint.mint_authority() {
+    match mint.mint_authority()? {
         Some(mint_authority) => validate_owner(mint_authority, owner_info, remaining)?,
         None => return Err(TokenError::FixedSupply.into()),
     }

--- a/p-token/src/processor/shared/toggle_account_state.rs
+++ b/p-token/src/processor/shared/toggle_account_state.rs
@@ -18,7 +18,7 @@ pub fn process_toggle_account_state(accounts: &[AccountInfo], freeze: bool) -> P
     let source_account =
         unsafe { load_mut::<Account>(source_account_info.borrow_mut_data_unchecked())? };
 
-    if freeze == source_account.is_frozen() {
+    if freeze == source_account.is_frozen()? {
         return Err(TokenError::InvalidState.into());
     }
     if source_account.is_native() {
@@ -34,16 +34,16 @@ pub fn process_toggle_account_state(accounts: &[AccountInfo], freeze: bool) -> P
     // passed in, one of them will fail the `load` check.
     let mint = unsafe { load::<Mint>(mint_info.borrow_data_unchecked())? };
 
-    match mint.freeze_authority() {
+    match mint.freeze_authority()? {
         Some(authority) => validate_owner(authority, authority_info, remaining),
         None => Err(TokenError::MintCannotFreeze.into()),
     }?;
 
-    source_account.state = if freeze {
+    source_account.set_account_state(if freeze {
         AccountState::Frozen
     } else {
         AccountState::Initialized
-    };
+    });
 
     Ok(())
 }

--- a/p-token/src/processor/shared/toggle_account_state.rs
+++ b/p-token/src/processor/shared/toggle_account_state.rs
@@ -34,7 +34,7 @@ pub fn process_toggle_account_state(accounts: &[AccountInfo], freeze: bool) -> P
     // passed in, one of them will fail the `load` check.
     let mint = unsafe { load::<Mint>(mint_info.borrow_data_unchecked())? };
 
-    match mint.freeze_authority()? {
+    match mint.freeze_authority() {
         Some(authority) => validate_owner(authority, authority_info, remaining),
         None => Err(TokenError::MintCannotFreeze.into()),
     }?;

--- a/p-token/src/processor/shared/transfer.rs
+++ b/p-token/src/processor/shared/transfer.rs
@@ -77,7 +77,7 @@ pub fn process_transfer(
     //     destination accounts are not frozen, have the same mint, and the source
     //     account has enough tokens.
     let remaining_amount = if self_transfer {
-        if source_account.is_frozen() {
+        if source_account.is_frozen()? {
             return Err(TokenError::AccountFrozen.into());
         }
 
@@ -92,7 +92,7 @@ pub fn process_transfer(
         let destination_account =
             unsafe { load::<Account>(destination_account_info.borrow_data_unchecked())? };
 
-        if source_account.is_frozen() || destination_account.is_frozen() {
+        if source_account.is_frozen()? || destination_account.is_frozen()? {
             return Err(TokenError::AccountFrozen.into());
         }
 
@@ -126,7 +126,7 @@ pub fn process_transfer(
 
     // Validates the authority (delegate or owner).
 
-    if source_account.delegate() == Some(authority_info.key()) {
+    if source_account.delegate()? == Some(authority_info.key()) {
         validate_owner(authority_info.key(), authority_info, remaining)?;
 
         let delegated_amount = source_account

--- a/p-token/src/processor/shared/transfer.rs
+++ b/p-token/src/processor/shared/transfer.rs
@@ -126,7 +126,7 @@ pub fn process_transfer(
 
     // Validates the authority (delegate or owner).
 
-    if source_account.delegate()? == Some(authority_info.key()) {
+    if source_account.delegate() == Some(authority_info.key()) {
         validate_owner(authority_info.key(), authority_info, remaining)?;
 
         let delegated_amount = source_account

--- a/p-token/src/processor/transfer.rs
+++ b/p-token/src/processor/transfer.rs
@@ -1,6 +1,7 @@
 use {
     super::shared,
-    pinocchio::{account_info::AccountInfo, program_error::ProgramError, ProgramResult},
+    pinocchio::{account_info::AccountInfo, ProgramResult},
+    spl_token_interface::error::TokenError,
 };
 
 #[inline(always)]
@@ -8,7 +9,7 @@ pub fn process_transfer(accounts: &[AccountInfo], instruction_data: &[u8]) -> Pr
     let amount = u64::from_le_bytes(
         instruction_data
             .try_into()
-            .map_err(|_error| ProgramError::InvalidInstructionData)?,
+            .map_err(|_error| TokenError::InvalidInstruction)?,
     );
 
     shared::transfer::process_transfer(accounts, amount, None)

--- a/p-token/src/processor/transfer.rs
+++ b/p-token/src/processor/transfer.rs
@@ -1,17 +1,11 @@
 use {
-    super::{shared, U64_BYTES},
+    super::{shared, unpack_amount},
     pinocchio::{account_info::AccountInfo, ProgramResult},
-    spl_token_interface::error::TokenError,
 };
 
 #[inline(always)]
 pub fn process_transfer(accounts: &[AccountInfo], instruction_data: &[u8]) -> ProgramResult {
-    let amount = if instruction_data.len() >= U64_BYTES {
-        // SAFETY: The minimum size of the instruction data is `U64_BYTES` bytes.
-        unsafe { u64::from_le_bytes(*(instruction_data.as_ptr() as *const [u8; U64_BYTES])) }
-    } else {
-        return Err(TokenError::InvalidInstruction.into());
-    };
+    let amount = unpack_amount(instruction_data)?;
 
     shared::transfer::process_transfer(accounts, amount, None)
 }

--- a/p-token/src/processor/transfer.rs
+++ b/p-token/src/processor/transfer.rs
@@ -1,16 +1,17 @@
 use {
-    super::shared,
+    super::{shared, U64_BYTES},
     pinocchio::{account_info::AccountInfo, ProgramResult},
     spl_token_interface::error::TokenError,
 };
 
 #[inline(always)]
 pub fn process_transfer(accounts: &[AccountInfo], instruction_data: &[u8]) -> ProgramResult {
-    let amount = u64::from_le_bytes(
-        instruction_data
-            .try_into()
-            .map_err(|_error| TokenError::InvalidInstruction)?,
-    );
+    let amount = if instruction_data.len() >= U64_BYTES {
+        // SAFETY: The minimum size of the instruction data is `U64_BYTES` bytes.
+        unsafe { u64::from_le_bytes(*(instruction_data.as_ptr() as *const [u8; U64_BYTES])) }
+    } else {
+        return Err(TokenError::InvalidInstruction.into());
+    };
 
     shared::transfer::process_transfer(accounts, amount, None)
 }

--- a/p-token/src/processor/transfer_checked.rs
+++ b/p-token/src/processor/transfer_checked.rs
@@ -1,7 +1,6 @@
 use {
-    super::{shared, U64_BYTES},
+    super::{shared, unpack_amount_and_decimals},
     pinocchio::{account_info::AccountInfo, ProgramResult},
-    spl_token_interface::error::TokenError,
 };
 
 #[inline(always)]
@@ -9,17 +8,7 @@ pub fn process_transfer_checked(
     accounts: &[AccountInfo],
     instruction_data: &[u8],
 ) -> ProgramResult {
-    // expected u64 (8) + u8 (1)
-    let (amount, decimals) = if instruction_data.len() >= 9 {
-        let (amount, decimals) = instruction_data.split_at(U64_BYTES);
-        (
-            // SAFETY: The size of `amount` is `U64_BYTES` bytes.
-            unsafe { u64::from_le_bytes(*(amount.as_ptr() as *const [u8; U64_BYTES])) },
-            decimals.first().copied(),
-        )
-    } else {
-        return Err(TokenError::InvalidInstruction.into());
-    };
+    let (amount, decimals) = unpack_amount_and_decimals(instruction_data)?;
 
-    shared::transfer::process_transfer(accounts, amount, decimals)
+    shared::transfer::process_transfer(accounts, amount, Some(decimals))
 }

--- a/p-token/src/processor/transfer_checked.rs
+++ b/p-token/src/processor/transfer_checked.rs
@@ -10,7 +10,7 @@ pub fn process_transfer_checked(
     instruction_data: &[u8],
 ) -> ProgramResult {
     // expected u64 (8) + u8 (1)
-    let (amount, decimals) = if instruction_data.len() == 9 {
+    let (amount, decimals) = if instruction_data.len() >= 9 {
         let (amount, decimals) = instruction_data.split_at(U64_BYTES);
         (
             // SAFETY: The size of `amount` is `U64_BYTES` bytes.

--- a/p-token/src/processor/transfer_checked.rs
+++ b/p-token/src/processor/transfer_checked.rs
@@ -1,6 +1,7 @@
 use {
     super::shared,
-    pinocchio::{account_info::AccountInfo, program_error::ProgramError, ProgramResult},
+    pinocchio::{account_info::AccountInfo, ProgramResult},
+    spl_token_interface::error::TokenError,
 };
 
 #[inline(always)]
@@ -16,7 +17,7 @@ pub fn process_transfer_checked(
             decimals.first().copied(),
         )
     } else {
-        return Err(ProgramError::InvalidInstructionData);
+        return Err(TokenError::InvalidInstruction.into());
     };
 
     shared::transfer::process_transfer(accounts, amount, decimals)

--- a/p-token/src/processor/transfer_checked.rs
+++ b/p-token/src/processor/transfer_checked.rs
@@ -1,5 +1,5 @@
 use {
-    super::shared,
+    super::{shared, U64_BYTES},
     pinocchio::{account_info::AccountInfo, ProgramResult},
     spl_token_interface::error::TokenError,
 };
@@ -11,9 +11,10 @@ pub fn process_transfer_checked(
 ) -> ProgramResult {
     // expected u64 (8) + u8 (1)
     let (amount, decimals) = if instruction_data.len() == 9 {
-        let (amount, decimals) = instruction_data.split_at(core::mem::size_of::<u64>());
+        let (amount, decimals) = instruction_data.split_at(U64_BYTES);
         (
-            u64::from_le_bytes(amount.try_into().unwrap()),
+            // SAFETY: The size of `amount` is `U64_BYTES` bytes.
+            unsafe { u64::from_le_bytes(*(amount.as_ptr() as *const [u8; U64_BYTES])) },
             decimals.first().copied(),
         )
     } else {

--- a/p-token/src/processor/ui_amount_to_amount.rs
+++ b/p-token/src/processor/ui_amount_to_amount.rs
@@ -15,8 +15,7 @@ pub fn process_ui_amount_to_amount(
     accounts: &[AccountInfo],
     instruction_data: &[u8],
 ) -> ProgramResult {
-    let ui_amount =
-        from_utf8(instruction_data).map_err(|_error| ProgramError::InvalidInstructionData)?;
+    let ui_amount = from_utf8(instruction_data).map_err(|_error| TokenError::InvalidInstruction)?;
 
     let mint_info = accounts.first().ok_or(ProgramError::NotEnoughAccountKeys)?;
     check_account_owner(mint_info)?;

--- a/p-token/src/processor/withdraw_excess_lamports.rs
+++ b/p-token/src/processor/withdraw_excess_lamports.rs
@@ -36,7 +36,7 @@ pub fn process_withdraw_excess_lamports(accounts: &[AccountInfo]) -> ProgramResu
             // SAFETY: `source_data` has the same length as `Mint`.
             let mint = unsafe { load::<Mint>(source_data)? };
 
-            if let Some(mint_authority) = mint.mint_authority()? {
+            if let Some(mint_authority) = mint.mint_authority() {
                 validate_owner(mint_authority, authority_info, remaining)?;
             } else {
                 return Err(TokenError::AuthorityTypeNotSupported.into());

--- a/p-token/src/processor/withdraw_excess_lamports.rs
+++ b/p-token/src/processor/withdraw_excess_lamports.rs
@@ -36,7 +36,7 @@ pub fn process_withdraw_excess_lamports(accounts: &[AccountInfo]) -> ProgramResu
             // SAFETY: `source_data` has the same length as `Mint`.
             let mint = unsafe { load::<Mint>(source_data)? };
 
-            if let Some(mint_authority) = mint.mint_authority() {
+            if let Some(mint_authority) = mint.mint_authority()? {
                 validate_owner(mint_authority, authority_info, remaining)?;
             } else {
                 return Err(TokenError::AuthorityTypeNotSupported.into());


### PR DESCRIPTION
### Problem

Fuzzing p-token has revealed mismatches in the error codes returned by p-token compared to spl-token implementation.

### Solution

Fix the mismatches. In some cases, extra validation on the account data was needed to replicate the same error code.