### PR TITLE
p-token: Clean-up test_case annotation

### DIFF
--- a/p-token/tests/amount_to_ui_amount.rs
+++ b/p-token/tests/amount_to_ui_amount.rs
@@ -6,9 +6,8 @@ use {
     solana_sdk::{pubkey::Pubkey, signature::Signer, transaction::Transaction},
 };
 
-#[test_case::test_case(TOKEN_PROGRAM_ID ; "p-token")]
 #[tokio::test]
-async fn amount_to_ui_amount(token_program: Pubkey) {
+async fn amount_to_ui_amount() {
     let mut context = ProgramTest::new("pinocchio_token_program", TOKEN_PROGRAM_ID, None)
         .start_with_context()
         .await;
@@ -22,15 +21,13 @@ async fn amount_to_ui_amount(token_program: Pubkey) {
         &mut context,
         mint_authority,
         Some(freeze_authority),
-        &token_program,
+        &TOKEN_PROGRAM_ID,
     )
     .await
     .unwrap();
 
-    let mut amount_to_ui_amount_ix =
+    let amount_to_ui_amount_ix =
         spl_token::instruction::amount_to_ui_amount(&spl_token::ID, &mint, 1000).unwrap();
-    // Switches the program id to the token program.
-    amount_to_ui_amount_ix.program_id = token_program;
 
     let tx = Transaction::new_signed_with_payer(
         &[amount_to_ui_amount_ix],

--- a/p-token/tests/approve.rs
+++ b/p-token/tests/approve.rs
@@ -11,9 +11,8 @@ use {
     },
 };
 
-#[test_case::test_case(TOKEN_PROGRAM_ID ; "p-token")]
 #[tokio::test]
-async fn approve(token_program: Pubkey) {
+async fn approve() {
     let mut context = ProgramTest::new("pinocchio_token_program", TOKEN_PROGRAM_ID, None)
         .start_with_context()
         .await;
@@ -27,7 +26,7 @@ async fn approve(token_program: Pubkey) {
         &mut context,
         mint_authority.pubkey(),
         Some(freeze_authority),
-        &token_program,
+        &TOKEN_PROGRAM_ID,
     )
     .await
     .unwrap();
@@ -36,7 +35,8 @@ async fn approve(token_program: Pubkey) {
 
     let owner = Keypair::new();
 
-    let account = account::initialize(&mut context, &mint, &owner.pubkey(), &token_program).await;
+    let account =
+        account::initialize(&mut context, &mint, &owner.pubkey(), &TOKEN_PROGRAM_ID).await;
 
     mint::mint(
         &mut context,
@@ -44,7 +44,7 @@ async fn approve(token_program: Pubkey) {
         &account,
         &mint_authority,
         100,
-        &token_program,
+        &TOKEN_PROGRAM_ID,
     )
     .await
     .unwrap();
@@ -53,7 +53,7 @@ async fn approve(token_program: Pubkey) {
 
     let delegate = Pubkey::new_unique();
 
-    let mut approve_ix = spl_token::instruction::approve(
+    let approve_ix = spl_token::instruction::approve(
         &spl_token::ID,
         &account,
         &delegate,
@@ -62,7 +62,6 @@ async fn approve(token_program: Pubkey) {
         50,
     )
     .unwrap();
-    approve_ix.program_id = token_program;
 
     let tx = Transaction::new_signed_with_payer(
         &[approve_ix],

--- a/p-token/tests/approve_checked.rs
+++ b/p-token/tests/approve_checked.rs
@@ -11,9 +11,8 @@ use {
     },
 };
 
-#[test_case::test_case(TOKEN_PROGRAM_ID ; "p-token")]
 #[tokio::test]
-async fn approve_checked(token_program: Pubkey) {
+async fn approve_checked() {
     let mut context = ProgramTest::new("pinocchio_token_program", TOKEN_PROGRAM_ID, None)
         .start_with_context()
         .await;
@@ -27,7 +26,7 @@ async fn approve_checked(token_program: Pubkey) {
         &mut context,
         mint_authority.pubkey(),
         Some(freeze_authority),
-        &token_program,
+        &TOKEN_PROGRAM_ID,
     )
     .await
     .unwrap();
@@ -36,7 +35,8 @@ async fn approve_checked(token_program: Pubkey) {
 
     let owner = Keypair::new();
 
-    let account = account::initialize(&mut context, &mint, &owner.pubkey(), &token_program).await;
+    let account =
+        account::initialize(&mut context, &mint, &owner.pubkey(), &TOKEN_PROGRAM_ID).await;
 
     mint::mint(
         &mut context,
@@ -44,7 +44,7 @@ async fn approve_checked(token_program: Pubkey) {
         &account,
         &mint_authority,
         100,
-        &token_program,
+        &TOKEN_PROGRAM_ID,
     )
     .await
     .unwrap();
@@ -53,8 +53,8 @@ async fn approve_checked(token_program: Pubkey) {
 
     let delegate = Pubkey::new_unique();
 
-    let mut approve_ix = spl_token::instruction::approve_checked(
-        &spl_token::ID,
+    let approve_ix = spl_token::instruction::approve_checked(
+        &TOKEN_PROGRAM_ID,
         &account,
         &mint,
         &delegate,
@@ -64,7 +64,6 @@ async fn approve_checked(token_program: Pubkey) {
         4,
     )
     .unwrap();
-    approve_ix.program_id = token_program;
 
     let tx = Transaction::new_signed_with_payer(
         &[approve_ix],

--- a/p-token/tests/batch.rs
+++ b/p-token/tests/batch.rs
@@ -40,9 +40,8 @@ fn batch_instruction(instructions: Vec<Instruction>) -> Result<Instruction, Prog
     })
 }
 
-#[test_case::test_case(TOKEN_PROGRAM_ID ; "p-token")]
 #[tokio::test]
-async fn batch(token_program: Pubkey) {
+async fn batch() {
     let context = ProgramTest::new("pinocchio_token_program", TOKEN_PROGRAM_ID, None)
         .start_with_context()
         .await;
@@ -63,10 +62,10 @@ async fn batch(token_program: Pubkey) {
         &mint_a.pubkey(),
         mint_rent,
         mint_len as u64,
-        &token_program,
+        &TOKEN_PROGRAM_ID,
     );
     let initialize_mint_ix = spl_token::instruction::initialize_mint(
-        &token_program,
+        &TOKEN_PROGRAM_ID,
         &mint_a.pubkey(),
         &mint_authority.pubkey(),
         None,
@@ -82,10 +81,10 @@ async fn batch(token_program: Pubkey) {
         &mint_b.pubkey(),
         mint_rent,
         mint_len as u64,
-        &token_program,
+        &TOKEN_PROGRAM_ID,
     );
     let initialize_mint_with_freeze_authority_ix = spl_token::instruction::initialize_mint2(
-        &token_program,
+        &TOKEN_PROGRAM_ID,
         &mint_b.pubkey(),
         &mint_authority.pubkey(),
         Some(&freeze_authority),
@@ -104,24 +103,24 @@ async fn batch(token_program: Pubkey) {
         &owner_a_ta_a.pubkey(),
         account_rent,
         account_len as u64,
-        &token_program,
+        &TOKEN_PROGRAM_ID,
     );
     let create_owner_b_ta_a = system_instruction::create_account(
         &context.payer.pubkey(),
         &owner_b_ta_a.pubkey(),
         account_rent,
         account_len as u64,
-        &token_program,
+        &TOKEN_PROGRAM_ID,
     );
     let intialize_owner_a_ta_a = spl_token::instruction::initialize_account3(
-        &token_program,
+        &TOKEN_PROGRAM_ID,
         &owner_a_ta_a.pubkey(),
         &mint_a.pubkey(),
         &owner_a.pubkey(),
     )
     .unwrap();
     let intialize_owner_b_ta_a = spl_token::instruction::initialize_account3(
-        &token_program,
+        &TOKEN_PROGRAM_ID,
         &owner_b_ta_a.pubkey(),
         &mint_a.pubkey(),
         &owner_b.pubkey(),
@@ -130,7 +129,7 @@ async fn batch(token_program: Pubkey) {
 
     // Mint Token A to Owner A
     let mint_token_a_to_owner_a = spl_token::instruction::mint_to(
-        &token_program,
+        &TOKEN_PROGRAM_ID,
         &mint_a.pubkey(),
         &owner_a_ta_a.pubkey(),
         &mint_authority.pubkey(),
@@ -141,7 +140,7 @@ async fn batch(token_program: Pubkey) {
 
     // Transfer Token A from Owner A to Owner B
     let transfer_token_a_to_owner_b = spl_token::instruction::transfer(
-        &token_program,
+        &TOKEN_PROGRAM_ID,
         &owner_a_ta_a.pubkey(),
         &owner_b_ta_a.pubkey(),
         &owner_a.pubkey(),
@@ -152,7 +151,7 @@ async fn batch(token_program: Pubkey) {
 
     // Close Token A
     let close_owner_a_ta_a = spl_token::instruction::close_account(
-        &token_program,
+        &TOKEN_PROGRAM_ID,
         &owner_a_ta_a.pubkey(),
         &owner_a.pubkey(),
         &owner_a.pubkey(),

--- a/p-token/tests/burn.rs
+++ b/p-token/tests/burn.rs
@@ -11,9 +11,8 @@ use {
     },
 };
 
-#[test_case::test_case(TOKEN_PROGRAM_ID ; "p-token")]
 #[tokio::test]
-async fn burn(token_program: Pubkey) {
+async fn burn() {
     let mut context = ProgramTest::new("pinocchio_token_program", TOKEN_PROGRAM_ID, None)
         .start_with_context()
         .await;
@@ -27,7 +26,7 @@ async fn burn(token_program: Pubkey) {
         &mut context,
         mint_authority.pubkey(),
         Some(freeze_authority),
-        &token_program,
+        &TOKEN_PROGRAM_ID,
     )
     .await
     .unwrap();
@@ -36,7 +35,8 @@ async fn burn(token_program: Pubkey) {
 
     let owner = Keypair::new();
 
-    let account = account::initialize(&mut context, &mint, &owner.pubkey(), &token_program).await;
+    let account =
+        account::initialize(&mut context, &mint, &owner.pubkey(), &TOKEN_PROGRAM_ID).await;
 
     mint::mint(
         &mut context,
@@ -44,17 +44,16 @@ async fn burn(token_program: Pubkey) {
         &account,
         &mint_authority,
         100,
-        &token_program,
+        &TOKEN_PROGRAM_ID,
     )
     .await
     .unwrap();
 
     // When we burn 50 tokens.
 
-    let mut burn_ix =
+    let burn_ix =
         spl_token::instruction::burn(&spl_token::ID, &account, &mint, &owner.pubkey(), &[], 50)
             .unwrap();
-    burn_ix.program_id = token_program;
 
     let tx = Transaction::new_signed_with_payer(
         &[burn_ix],

--- a/p-token/tests/burn_checked.rs
+++ b/p-token/tests/burn_checked.rs
@@ -11,9 +11,8 @@ use {
     },
 };
 
-#[test_case::test_case(TOKEN_PROGRAM_ID ; "p-token")]
 #[tokio::test]
-async fn burn_checked(token_program: Pubkey) {
+async fn burn_checked() {
     let mut context = ProgramTest::new("pinocchio_token_program", TOKEN_PROGRAM_ID, None)
         .start_with_context()
         .await;
@@ -27,7 +26,7 @@ async fn burn_checked(token_program: Pubkey) {
         &mut context,
         mint_authority.pubkey(),
         Some(freeze_authority),
-        &token_program,
+        &TOKEN_PROGRAM_ID,
     )
     .await
     .unwrap();
@@ -36,7 +35,8 @@ async fn burn_checked(token_program: Pubkey) {
 
     let owner = Keypair::new();
 
-    let account = account::initialize(&mut context, &mint, &owner.pubkey(), &token_program).await;
+    let account =
+        account::initialize(&mut context, &mint, &owner.pubkey(), &TOKEN_PROGRAM_ID).await;
 
     mint::mint(
         &mut context,
@@ -44,14 +44,14 @@ async fn burn_checked(token_program: Pubkey) {
         &account,
         &mint_authority,
         100,
-        &token_program,
+        &TOKEN_PROGRAM_ID,
     )
     .await
     .unwrap();
 
     // When we burn 50 tokens.
 
-    let mut burn_ix = spl_token::instruction::burn_checked(
+    let burn_ix = spl_token::instruction::burn_checked(
         &spl_token::ID,
         &account,
         &mint,
@@ -61,7 +61,6 @@ async fn burn_checked(token_program: Pubkey) {
         4,
     )
     .unwrap();
-    burn_ix.program_id = token_program;
 
     let tx = Transaction::new_signed_with_payer(
         &[burn_ix],

--- a/p-token/tests/close_account.rs
+++ b/p-token/tests/close_account.rs
@@ -10,9 +10,8 @@ use {
     },
 };
 
-#[test_case::test_case(TOKEN_PROGRAM_ID ; "p-token")]
 #[tokio::test]
-async fn close_account(token_program: Pubkey) {
+async fn close_account() {
     let mut context = ProgramTest::new("pinocchio_token_program", TOKEN_PROGRAM_ID, None)
         .start_with_context()
         .await;
@@ -26,7 +25,7 @@ async fn close_account(token_program: Pubkey) {
         &mut context,
         mint_authority.pubkey(),
         Some(freeze_authority),
-        &token_program,
+        &TOKEN_PROGRAM_ID,
     )
     .await
     .unwrap();
@@ -35,14 +34,15 @@ async fn close_account(token_program: Pubkey) {
 
     let owner = Keypair::new();
 
-    let account = account::initialize(&mut context, &mint, &owner.pubkey(), &token_program).await;
+    let account =
+        account::initialize(&mut context, &mint, &owner.pubkey(), &TOKEN_PROGRAM_ID).await;
 
     let token_account = context.banks_client.get_account(account).await.unwrap();
     assert!(token_account.is_some());
 
     // When we close the account.
 
-    let mut close_account_ix = spl_token::instruction::close_account(
+    let close_account_ix = spl_token::instruction::close_account(
         &spl_token::ID,
         &account,
         &owner.pubkey(),
@@ -50,7 +50,6 @@ async fn close_account(token_program: Pubkey) {
         &[],
     )
     .unwrap();
-    close_account_ix.program_id = token_program;
 
     let tx = Transaction::new_signed_with_payer(
         &[close_account_ix],

--- a/p-token/tests/freeze_account.rs
+++ b/p-token/tests/freeze_account.rs
@@ -5,16 +5,14 @@ use {
     solana_program_test::{tokio, ProgramTest},
     solana_sdk::{
         program_pack::Pack,
-        pubkey::Pubkey,
         signature::{Keypair, Signer},
         transaction::Transaction,
     },
     spl_token::state::AccountState,
 };
 
-#[test_case::test_case(TOKEN_PROGRAM_ID ; "p-token")]
 #[tokio::test]
-async fn freeze_account(token_program: Pubkey) {
+async fn freeze_account() {
     let mut context = ProgramTest::new("pinocchio_token_program", TOKEN_PROGRAM_ID, None)
         .start_with_context()
         .await;
@@ -28,7 +26,7 @@ async fn freeze_account(token_program: Pubkey) {
         &mut context,
         mint_authority.pubkey(),
         Some(freeze_authority.pubkey()),
-        &token_program,
+        &TOKEN_PROGRAM_ID,
     )
     .await
     .unwrap();
@@ -37,14 +35,15 @@ async fn freeze_account(token_program: Pubkey) {
 
     let owner = Keypair::new();
 
-    let account = account::initialize(&mut context, &mint, &owner.pubkey(), &token_program).await;
+    let account =
+        account::initialize(&mut context, &mint, &owner.pubkey(), &TOKEN_PROGRAM_ID).await;
 
     let token_account = context.banks_client.get_account(account).await.unwrap();
     assert!(token_account.is_some());
 
     // When we freeze the account.
 
-    let mut freeze_account_ix = spl_token::instruction::freeze_account(
+    let freeze_account_ix = spl_token::instruction::freeze_account(
         &spl_token::ID,
         &account,
         &mint,
@@ -52,7 +51,6 @@ async fn freeze_account(token_program: Pubkey) {
         &[],
     )
     .unwrap();
-    freeze_account_ix.program_id = token_program;
 
     let tx = Transaction::new_signed_with_payer(
         &[freeze_account_ix],

--- a/p-token/tests/initialize_account.rs
+++ b/p-token/tests/initialize_account.rs
@@ -12,9 +12,8 @@ use {
     },
 };
 
-#[test_case::test_case(TOKEN_PROGRAM_ID ; "p-token")]
 #[tokio::test]
-async fn initialize_account(token_program: Pubkey) {
+async fn initialize_account() {
     let mut context = ProgramTest::new("pinocchio_token_program", TOKEN_PROGRAM_ID, None)
         .start_with_context()
         .await;
@@ -28,7 +27,7 @@ async fn initialize_account(token_program: Pubkey) {
         &mut context,
         mint_authority,
         Some(freeze_authority),
-        &token_program,
+        &TOKEN_PROGRAM_ID,
     )
     .await
     .unwrap();
@@ -41,15 +40,13 @@ async fn initialize_account(token_program: Pubkey) {
     let account_size = 165;
     let rent = context.banks_client.get_rent().await.unwrap();
 
-    let mut initialize_ix = spl_token::instruction::initialize_account(
+    let initialize_ix = spl_token::instruction::initialize_account(
         &spl_token::ID,
         &account.pubkey(),
         &mint,
         &owner,
     )
     .unwrap();
-    // Switches the program id to the token program.
-    initialize_ix.program_id = token_program;
 
     // When a new mint account is created and initialized.
 
@@ -59,7 +56,7 @@ async fn initialize_account(token_program: Pubkey) {
             &account.pubkey(),
             rent.minimum_balance(account_size),
             account_size as u64,
-            &token_program,
+            &TOKEN_PROGRAM_ID,
         ),
         initialize_ix,
     ];

--- a/p-token/tests/initialize_account2.rs
+++ b/p-token/tests/initialize_account2.rs
@@ -12,9 +12,8 @@ use {
     },
 };
 
-#[test_case::test_case(TOKEN_PROGRAM_ID ; "p-token")]
 #[tokio::test]
-async fn initialize_account2(token_program: Pubkey) {
+async fn initialize_account2() {
     let mut context = ProgramTest::new("pinocchio_token_program", TOKEN_PROGRAM_ID, None)
         .start_with_context()
         .await;
@@ -28,7 +27,7 @@ async fn initialize_account2(token_program: Pubkey) {
         &mut context,
         mint_authority,
         Some(freeze_authority),
-        &token_program,
+        &TOKEN_PROGRAM_ID,
     )
     .await
     .unwrap();
@@ -41,15 +40,13 @@ async fn initialize_account2(token_program: Pubkey) {
     let account_size = 165;
     let rent = context.banks_client.get_rent().await.unwrap();
 
-    let mut initialize_ix = spl_token::instruction::initialize_account2(
+    let initialize_ix = spl_token::instruction::initialize_account2(
         &spl_token::ID,
         &account.pubkey(),
         &mint,
         &owner,
     )
     .unwrap();
-    // Switches the program id to the token program.
-    initialize_ix.program_id = token_program;
 
     // When a new mint account is created and initialized.
 
@@ -59,7 +56,7 @@ async fn initialize_account2(token_program: Pubkey) {
             &account.pubkey(),
             rent.minimum_balance(account_size),
             account_size as u64,
-            &token_program,
+            &TOKEN_PROGRAM_ID,
         ),
         initialize_ix,
     ];

--- a/p-token/tests/initialize_account3.rs
+++ b/p-token/tests/initialize_account3.rs
@@ -12,9 +12,8 @@ use {
     },
 };
 
-#[test_case::test_case(TOKEN_PROGRAM_ID ; "p-token")]
 #[tokio::test]
-async fn initialize_account3(token_program: Pubkey) {
+async fn initialize_account3() {
     let mut context = ProgramTest::new("pinocchio_token_program", TOKEN_PROGRAM_ID, None)
         .start_with_context()
         .await;
@@ -28,7 +27,7 @@ async fn initialize_account3(token_program: Pubkey) {
         &mut context,
         mint_authority,
         Some(freeze_authority),
-        &token_program,
+        &TOKEN_PROGRAM_ID,
     )
     .await
     .unwrap();
@@ -41,15 +40,13 @@ async fn initialize_account3(token_program: Pubkey) {
     let account_size = 165;
     let rent = context.banks_client.get_rent().await.unwrap();
 
-    let mut initialize_ix = spl_token::instruction::initialize_account3(
+    let initialize_ix = spl_token::instruction::initialize_account3(
         &spl_token::ID,
         &account.pubkey(),
         &mint,
         &owner,
     )
     .unwrap();
-    // Switches the program id to the token program.
-    initialize_ix.program_id = token_program;
 
     // When a new mint account is created and initialized.
 
@@ -59,7 +56,7 @@ async fn initialize_account3(token_program: Pubkey) {
             &account.pubkey(),
             rent.minimum_balance(account_size),
             account_size as u64,
-            &token_program,
+            &TOKEN_PROGRAM_ID,
         ),
         initialize_ix,
     ];

--- a/p-token/tests/initialize_mint.rs
+++ b/p-token/tests/initialize_mint.rs
@@ -15,9 +15,8 @@ use {
     std::mem::size_of,
 };
 
-#[test_case::test_case(TOKEN_PROGRAM_ID ; "p-token")]
 #[tokio::test]
-async fn initialize_mint(token_program: Pubkey) {
+async fn initialize_mint() {
     let context = ProgramTest::new("pinocchio_token_program", TOKEN_PROGRAM_ID, None)
         .start_with_context()
         .await;
@@ -31,7 +30,7 @@ async fn initialize_mint(token_program: Pubkey) {
     let account_size = size_of::<Mint>();
     let rent = context.banks_client.get_rent().await.unwrap();
 
-    let mut initialize_ix = spl_token::instruction::initialize_mint(
+    let initialize_ix = spl_token::instruction::initialize_mint(
         &spl_token::ID,
         &account.pubkey(),
         &mint_authority,
@@ -39,8 +38,6 @@ async fn initialize_mint(token_program: Pubkey) {
         0,
     )
     .unwrap();
-    // Switches the program id to the token program.
-    initialize_ix.program_id = token_program;
 
     // When a new mint account is created and initialized.
 
@@ -50,7 +47,7 @@ async fn initialize_mint(token_program: Pubkey) {
             &account.pubkey(),
             rent.minimum_balance(account_size),
             account_size as u64,
-            &token_program,
+            &TOKEN_PROGRAM_ID,
         ),
         initialize_ix,
     ];

--- a/p-token/tests/initialize_mint2.rs
+++ b/p-token/tests/initialize_mint2.rs
@@ -15,9 +15,8 @@ use {
     std::mem::size_of,
 };
 
-#[test_case::test_case(TOKEN_PROGRAM_ID ; "p-token")]
 #[tokio::test]
-async fn initialize_mint2(token_program: Pubkey) {
+async fn initialize_mint2() {
     let context = ProgramTest::new("pinocchio_token_program", TOKEN_PROGRAM_ID, None)
         .start_with_context()
         .await;
@@ -31,7 +30,7 @@ async fn initialize_mint2(token_program: Pubkey) {
     let account_size = size_of::<Mint>();
     let rent = context.banks_client.get_rent().await.unwrap();
 
-    let mut initialize_ix = spl_token::instruction::initialize_mint2(
+    let initialize_ix = spl_token::instruction::initialize_mint2(
         &spl_token::ID,
         &account.pubkey(),
         &mint_authority,
@@ -39,8 +38,6 @@ async fn initialize_mint2(token_program: Pubkey) {
         0,
     )
     .unwrap();
-    // Switches the program id to the token program.
-    initialize_ix.program_id = token_program;
 
     // When a new mint account is created and initialized.
 
@@ -50,7 +47,7 @@ async fn initialize_mint2(token_program: Pubkey) {
             &account.pubkey(),
             rent.minimum_balance(account_size),
             account_size as u64,
-            &token_program,
+            &TOKEN_PROGRAM_ID,
         ),
         initialize_ix,
     ];

--- a/p-token/tests/initialize_multisig.rs
+++ b/p-token/tests/initialize_multisig.rs
@@ -13,9 +13,8 @@ use {
     spl_token::state::Multisig,
 };
 
-#[test_case::test_case(TOKEN_PROGRAM_ID ; "p-token")]
 #[tokio::test]
-async fn initialize_multisig(token_program: Pubkey) {
+async fn initialize_multisig() {
     let context = ProgramTest::new("pinocchio_token_program", TOKEN_PROGRAM_ID, None)
         .start_with_context()
         .await;
@@ -30,15 +29,13 @@ async fn initialize_multisig(token_program: Pubkey) {
 
     let rent = context.banks_client.get_rent().await.unwrap();
 
-    let mut initialize_ix = spl_token::instruction::initialize_multisig(
+    let initialize_ix = spl_token::instruction::initialize_multisig(
         &spl_token::ID,
         &multisig.pubkey(),
         &signers,
         2,
     )
     .unwrap();
-    // Switches the program id to the token program.
-    initialize_ix.program_id = token_program;
 
     // When a new multisig account is created and initialized.
 
@@ -48,7 +45,7 @@ async fn initialize_multisig(token_program: Pubkey) {
             &multisig.pubkey(),
             rent.minimum_balance(Multisig::LEN),
             Multisig::LEN as u64,
-            &token_program,
+            &TOKEN_PROGRAM_ID,
         ),
         initialize_ix,
     ];

--- a/p-token/tests/initialize_multisig2.rs
+++ b/p-token/tests/initialize_multisig2.rs
@@ -13,9 +13,8 @@ use {
     spl_token::state::Multisig,
 };
 
-#[test_case::test_case(TOKEN_PROGRAM_ID ; "p-token")]
 #[tokio::test]
-async fn initialize_multisig2(token_program: Pubkey) {
+async fn initialize_multisig2() {
     let context = ProgramTest::new("pinocchio_token_program", TOKEN_PROGRAM_ID, None)
         .start_with_context()
         .await;
@@ -30,15 +29,13 @@ async fn initialize_multisig2(token_program: Pubkey) {
 
     let rent = context.banks_client.get_rent().await.unwrap();
 
-    let mut initialize_ix = spl_token::instruction::initialize_multisig2(
+    let initialize_ix = spl_token::instruction::initialize_multisig2(
         &spl_token::ID,
         &multisig.pubkey(),
         &signers,
         2,
     )
     .unwrap();
-    // Switches the program id to the token program.
-    initialize_ix.program_id = token_program;
 
     // When a new multisig account is created and initialized.
 
@@ -48,7 +45,7 @@ async fn initialize_multisig2(token_program: Pubkey) {
             &multisig.pubkey(),
             rent.minimum_balance(Multisig::LEN),
             Multisig::LEN as u64,
-            &token_program,
+            &TOKEN_PROGRAM_ID,
         ),
         initialize_ix,
     ];

--- a/p-token/tests/mint_to.rs
+++ b/p-token/tests/mint_to.rs
@@ -11,9 +11,8 @@ use {
     },
 };
 
-#[test_case::test_case(TOKEN_PROGRAM_ID ; "p-token")]
 #[tokio::test]
-async fn mint_to(token_program: Pubkey) {
+async fn mint_to() {
     let mut context = ProgramTest::new("pinocchio_token_program", TOKEN_PROGRAM_ID, None)
         .start_with_context()
         .await;
@@ -27,7 +26,7 @@ async fn mint_to(token_program: Pubkey) {
         &mut context,
         mint_authority.pubkey(),
         Some(freeze_authority),
-        &token_program,
+        &TOKEN_PROGRAM_ID,
     )
     .await
     .unwrap();
@@ -36,11 +35,12 @@ async fn mint_to(token_program: Pubkey) {
 
     let owner = Keypair::new();
 
-    let account = account::initialize(&mut context, &mint, &owner.pubkey(), &token_program).await;
+    let account =
+        account::initialize(&mut context, &mint, &owner.pubkey(), &TOKEN_PROGRAM_ID).await;
 
     // When we mint tokens to it.
 
-    let mut mint_ix = spl_token::instruction::mint_to(
+    let mint_ix = spl_token::instruction::mint_to(
         &spl_token::ID,
         &mint,
         &account,
@@ -49,8 +49,6 @@ async fn mint_to(token_program: Pubkey) {
         100,
     )
     .unwrap();
-    // Switches the program id to the token program.
-    mint_ix.program_id = token_program;
 
     let tx = Transaction::new_signed_with_payer(
         &[mint_ix],

--- a/p-token/tests/mint_to_checked.rs
+++ b/p-token/tests/mint_to_checked.rs
@@ -11,9 +11,8 @@ use {
     },
 };
 
-#[test_case::test_case(TOKEN_PROGRAM_ID ; "p-token")]
 #[tokio::test]
-async fn mint_to_checked(token_program: Pubkey) {
+async fn mint_to_checked() {
     let mut context = ProgramTest::new("pinocchio_token_program", TOKEN_PROGRAM_ID, None)
         .start_with_context()
         .await;
@@ -27,7 +26,7 @@ async fn mint_to_checked(token_program: Pubkey) {
         &mut context,
         mint_authority.pubkey(),
         Some(freeze_authority),
-        &token_program,
+        &TOKEN_PROGRAM_ID,
     )
     .await
     .unwrap();
@@ -36,11 +35,12 @@ async fn mint_to_checked(token_program: Pubkey) {
 
     let owner = Keypair::new();
 
-    let account = account::initialize(&mut context, &mint, &owner.pubkey(), &token_program).await;
+    let account =
+        account::initialize(&mut context, &mint, &owner.pubkey(), &TOKEN_PROGRAM_ID).await;
 
     // When we mint tokens to it.
 
-    let mut mint_ix = spl_token::instruction::mint_to_checked(
+    let mint_ix = spl_token::instruction::mint_to_checked(
         &spl_token::ID,
         &mint,
         &account,
@@ -50,8 +50,6 @@ async fn mint_to_checked(token_program: Pubkey) {
         4,
     )
     .unwrap();
-    // Switches the program id to the token program.
-    mint_ix.program_id = token_program;
 
     let tx = Transaction::new_signed_with_payer(
         &[mint_ix],

--- a/p-token/tests/revoke.rs
+++ b/p-token/tests/revoke.rs
@@ -11,9 +11,8 @@ use {
     },
 };
 
-#[test_case::test_case(TOKEN_PROGRAM_ID ; "p-token")]
 #[tokio::test]
-async fn revoke(token_program: Pubkey) {
+async fn revoke() {
     let mut context = ProgramTest::new("pinocchio_token_program", TOKEN_PROGRAM_ID, None)
         .start_with_context()
         .await;
@@ -27,7 +26,7 @@ async fn revoke(token_program: Pubkey) {
         &mut context,
         mint_authority.pubkey(),
         Some(freeze_authority),
-        &token_program,
+        &TOKEN_PROGRAM_ID,
     )
     .await
     .unwrap();
@@ -36,7 +35,8 @@ async fn revoke(token_program: Pubkey) {
 
     let owner = Keypair::new();
 
-    let account = account::initialize(&mut context, &mint, &owner.pubkey(), &token_program).await;
+    let account =
+        account::initialize(&mut context, &mint, &owner.pubkey(), &TOKEN_PROGRAM_ID).await;
 
     mint::mint(
         &mut context,
@@ -44,7 +44,7 @@ async fn revoke(token_program: Pubkey) {
         &account,
         &mint_authority,
         100,
-        &token_program,
+        &TOKEN_PROGRAM_ID,
     )
     .await
     .unwrap();
@@ -59,15 +59,14 @@ async fn revoke(token_program: Pubkey) {
         &delegate,
         &owner,
         50,
-        &token_program,
+        &TOKEN_PROGRAM_ID,
     )
     .await;
 
     // When we revoke the delegation.
 
-    let mut revoke_ix =
+    let revoke_ix =
         spl_token::instruction::revoke(&spl_token::ID, &account, &owner.pubkey(), &[]).unwrap();
-    revoke_ix.program_id = token_program;
 
     let tx = Transaction::new_signed_with_payer(
         &[revoke_ix],

--- a/p-token/tests/set_authority.rs
+++ b/p-token/tests/set_authority.rs
@@ -13,9 +13,8 @@ use {
     spl_token::instruction::AuthorityType,
 };
 
-#[test_case::test_case(TOKEN_PROGRAM_ID ; "p-token")]
 #[tokio::test]
-async fn set_authority(token_program: Pubkey) {
+async fn set_authority() {
     let mut context = ProgramTest::new("pinocchio_token_program", TOKEN_PROGRAM_ID, None)
         .start_with_context()
         .await;
@@ -29,7 +28,7 @@ async fn set_authority(token_program: Pubkey) {
         &mut context,
         mint_authority.pubkey(),
         Some(freeze_authority.pubkey()),
-        &token_program,
+        &TOKEN_PROGRAM_ID,
     )
     .await
     .unwrap();
@@ -38,7 +37,7 @@ async fn set_authority(token_program: Pubkey) {
 
     let new_authority = Pubkey::new_unique();
 
-    let mut set_authority_ix = spl_token::instruction::set_authority(
+    let set_authority_ix = spl_token::instruction::set_authority(
         &spl_token::ID,
         &mint,
         Some(&new_authority),
@@ -47,7 +46,6 @@ async fn set_authority(token_program: Pubkey) {
         &[],
     )
     .unwrap();
-    set_authority_ix.program_id = token_program;
 
     let tx = Transaction::new_signed_with_payer(
         &[set_authority_ix],

--- a/p-token/tests/thaw_account.rs
+++ b/p-token/tests/thaw_account.rs
@@ -5,16 +5,14 @@ use {
     solana_program_test::{tokio, ProgramTest},
     solana_sdk::{
         program_pack::Pack,
-        pubkey::Pubkey,
         signature::{Keypair, Signer},
         transaction::Transaction,
     },
     spl_token::state::AccountState,
 };
 
-#[test_case::test_case(TOKEN_PROGRAM_ID ; "p-token")]
 #[tokio::test]
-async fn thaw_account(token_program: Pubkey) {
+async fn thaw_account() {
     let mut context = ProgramTest::new("pinocchio_token_program", TOKEN_PROGRAM_ID, None)
         .start_with_context()
         .await;
@@ -28,7 +26,7 @@ async fn thaw_account(token_program: Pubkey) {
         &mut context,
         mint_authority.pubkey(),
         Some(freeze_authority.pubkey()),
-        &token_program,
+        &TOKEN_PROGRAM_ID,
     )
     .await
     .unwrap();
@@ -37,7 +35,8 @@ async fn thaw_account(token_program: Pubkey) {
 
     let owner = Keypair::new();
 
-    let account = account::initialize(&mut context, &mint, &owner.pubkey(), &token_program).await;
+    let account =
+        account::initialize(&mut context, &mint, &owner.pubkey(), &TOKEN_PROGRAM_ID).await;
 
     let token_account = context.banks_client.get_account(account).await.unwrap();
     assert!(token_account.is_some());
@@ -47,13 +46,13 @@ async fn thaw_account(token_program: Pubkey) {
         &account,
         &mint,
         &freeze_authority,
-        &token_program,
+        &TOKEN_PROGRAM_ID,
     )
     .await;
 
     // When we thaw the account.
 
-    let mut thaw_account_ix = spl_token::instruction::thaw_account(
+    let thaw_account_ix = spl_token::instruction::thaw_account(
         &spl_token::ID,
         &account,
         &mint,
@@ -61,7 +60,6 @@ async fn thaw_account(token_program: Pubkey) {
         &[],
     )
     .unwrap();
-    thaw_account_ix.program_id = token_program;
 
     let tx = Transaction::new_signed_with_payer(
         &[thaw_account_ix],

--- a/p-token/tests/transfer.rs
+++ b/p-token/tests/transfer.rs
@@ -11,9 +11,8 @@ use {
     },
 };
 
-#[test_case::test_case(TOKEN_PROGRAM_ID ; "p-token")]
 #[tokio::test]
-async fn transfer(token_program: Pubkey) {
+async fn transfer() {
     let mut context = ProgramTest::new("pinocchio_token_program", TOKEN_PROGRAM_ID, None)
         .start_with_context()
         .await;
@@ -27,7 +26,7 @@ async fn transfer(token_program: Pubkey) {
         &mut context,
         mint_authority.pubkey(),
         Some(freeze_authority),
-        &token_program,
+        &TOKEN_PROGRAM_ID,
     )
     .await
     .unwrap();
@@ -36,7 +35,8 @@ async fn transfer(token_program: Pubkey) {
 
     let owner = Keypair::new();
 
-    let account = account::initialize(&mut context, &mint, &owner.pubkey(), &token_program).await;
+    let account =
+        account::initialize(&mut context, &mint, &owner.pubkey(), &TOKEN_PROGRAM_ID).await;
 
     mint::mint(
         &mut context,
@@ -44,7 +44,7 @@ async fn transfer(token_program: Pubkey) {
         &account,
         &mint_authority,
         100,
-        &token_program,
+        &TOKEN_PROGRAM_ID,
     )
     .await
     .unwrap();
@@ -54,9 +54,9 @@ async fn transfer(token_program: Pubkey) {
     let destination = Pubkey::new_unique();
 
     let destination_account =
-        account::initialize(&mut context, &mint, &destination, &token_program).await;
+        account::initialize(&mut context, &mint, &destination, &TOKEN_PROGRAM_ID).await;
 
-    let mut transfer_ix = spl_token::instruction::transfer(
+    let transfer_ix = spl_token::instruction::transfer(
         &spl_token::ID,
         &account,
         &destination_account,
@@ -65,7 +65,6 @@ async fn transfer(token_program: Pubkey) {
         100,
     )
     .unwrap();
-    transfer_ix.program_id = token_program;
 
     let tx = Transaction::new_signed_with_payer(
         &[transfer_ix],

--- a/p-token/tests/transfer_checked.rs
+++ b/p-token/tests/transfer_checked.rs
@@ -11,9 +11,8 @@ use {
     },
 };
 
-#[test_case::test_case(TOKEN_PROGRAM_ID ; "p-token")]
 #[tokio::test]
-async fn transfer_checked(token_program: Pubkey) {
+async fn transfer_checked() {
     let mut context = ProgramTest::new("pinocchio_token_program", TOKEN_PROGRAM_ID, None)
         .start_with_context()
         .await;
@@ -27,7 +26,7 @@ async fn transfer_checked(token_program: Pubkey) {
         &mut context,
         mint_authority.pubkey(),
         Some(freeze_authority),
-        &token_program,
+        &TOKEN_PROGRAM_ID,
     )
     .await
     .unwrap();
@@ -36,7 +35,8 @@ async fn transfer_checked(token_program: Pubkey) {
 
     let owner = Keypair::new();
 
-    let account = account::initialize(&mut context, &mint, &owner.pubkey(), &token_program).await;
+    let account =
+        account::initialize(&mut context, &mint, &owner.pubkey(), &TOKEN_PROGRAM_ID).await;
 
     mint::mint(
         &mut context,
@@ -44,7 +44,7 @@ async fn transfer_checked(token_program: Pubkey) {
         &account,
         &mint_authority,
         100,
-        &token_program,
+        &TOKEN_PROGRAM_ID,
     )
     .await
     .unwrap();
@@ -54,9 +54,9 @@ async fn transfer_checked(token_program: Pubkey) {
     let destination = Pubkey::new_unique();
 
     let destination_account =
-        account::initialize(&mut context, &mint, &destination, &token_program).await;
+        account::initialize(&mut context, &mint, &destination, &TOKEN_PROGRAM_ID).await;
 
-    let mut transfer_ix = spl_token::instruction::transfer_checked(
+    let transfer_ix = spl_token::instruction::transfer_checked(
         &spl_token::ID,
         &account,
         &mint,
@@ -67,7 +67,6 @@ async fn transfer_checked(token_program: Pubkey) {
         4,
     )
     .unwrap();
-    transfer_ix.program_id = token_program;
 
     let tx = Transaction::new_signed_with_payer(
         &[transfer_ix],

--- a/p-token/tests/ui_amount_to_amount.rs
+++ b/p-token/tests/ui_amount_to_amount.rs
@@ -6,9 +6,8 @@ use {
     solana_sdk::{pubkey::Pubkey, signature::Signer, transaction::Transaction},
 };
 
-#[test_case::test_case(TOKEN_PROGRAM_ID ; "p-token")]
 #[tokio::test]
-async fn ui_amount_to_amount(token_program: Pubkey) {
+async fn ui_amount_to_amount() {
     let mut context = ProgramTest::new("pinocchio_token_program", TOKEN_PROGRAM_ID, None)
         .start_with_context()
         .await;
@@ -22,15 +21,13 @@ async fn ui_amount_to_amount(token_program: Pubkey) {
         &mut context,
         mint_authority,
         Some(freeze_authority),
-        &token_program,
+        &TOKEN_PROGRAM_ID,
     )
     .await
     .unwrap();
 
-    let mut ui_amount_to_amount_ix =
+    let ui_amount_to_amount_ix =
         spl_token::instruction::ui_amount_to_amount(&spl_token::ID, &mint, "1000.00").unwrap();
-    // Switches the program id to the token program.
-    ui_amount_to_amount_ix.program_id = token_program;
 
     let tx = Transaction::new_signed_with_payer(
         &[ui_amount_to_amount_ix],

--- a/p-token/tests/withdraw_excess_lamports.rs
+++ b/p-token/tests/withdraw_excess_lamports.rs
@@ -8,6 +8,7 @@ use {
     solana_program_test::{tokio, BanksClientError, ProgramTest},
     solana_sdk::{
         instruction::InstructionError,
+        program_pack::Pack,
         pubkey::Pubkey,
         signature::{Keypair, Signer},
         system_instruction,
@@ -755,6 +756,380 @@ async fn fail_withdraw_excess_lamports_from_multisig_missing_signer(token_progra
         BanksClientError::TransactionError(TransactionError::InstructionError(
             _,
             InstructionError::MissingRequiredSignature
+        ))
+    );
+}
+
+#[test_case::test_case(TOKEN_PROGRAM_ID ; "p-token")]
+#[tokio::test]
+async fn withdraw_excess_lamports_from_mint_with_no_authority(token_program: Pubkey) {
+    let context = ProgramTest::new("pinocchio_token_program", TOKEN_PROGRAM_ID, None)
+        .start_with_context()
+        .await;
+
+    let excess_lamports = 4_000_000_000_000;
+
+    // Given a mint authority, freeze authority and an account keypair.
+
+    let mint_authority = Keypair::new();
+    let freeze_authority = Pubkey::new_unique();
+    let mint_account = Keypair::new();
+    let account_pubkey = mint_account.pubkey();
+
+    let account_size = size_of::<Mint>();
+    let rent = context.banks_client.get_rent().await.unwrap();
+
+    let mut initialize_ix = spl_token::instruction::initialize_mint(
+        &spl_token::ID,
+        &mint_account.pubkey(),
+        &mint_authority.pubkey(),
+        Some(&freeze_authority),
+        0,
+    )
+    .unwrap();
+    // Switches the program id to the token program.
+    initialize_ix.program_id = token_program;
+
+    // And we initialize a mint account with excess lamports.
+
+    let instructions = vec![
+        system_instruction::create_account(
+            &context.payer.pubkey(),
+            &mint_account.pubkey(),
+            rent.minimum_balance(account_size) + excess_lamports,
+            account_size as u64,
+            &token_program,
+        ),
+        initialize_ix,
+    ];
+
+    let tx = Transaction::new_signed_with_payer(
+        &instructions,
+        Some(&context.payer.pubkey()),
+        &[&context.payer, &mint_account],
+        context.last_blockhash,
+    );
+    context.banks_client.process_transaction(tx).await.unwrap();
+
+    let account = context
+        .banks_client
+        .get_account(mint_account.pubkey())
+        .await
+        .unwrap();
+
+    assert!(account.is_some());
+
+    let account = account.unwrap();
+    assert_eq!(
+        account.lamports,
+        rent.minimum_balance(account_size) + excess_lamports
+    );
+
+    // And we remove the mint authority.
+
+    let mut set_authority_ix = spl_token::instruction::set_authority(
+        &spl_token::ID,
+        &mint_account.pubkey(),
+        None,
+        spl_token::instruction::AuthorityType::MintTokens,
+        &mint_authority.pubkey(),
+        &[&mint_authority.pubkey()],
+    )
+    .unwrap();
+    // Switches the program id to the token program.
+    set_authority_ix.program_id = token_program;
+
+    let tx = Transaction::new_signed_with_payer(
+        &[set_authority_ix],
+        Some(&context.payer.pubkey()),
+        &[&context.payer, &mint_authority],
+        context.last_blockhash,
+    );
+    context.banks_client.process_transaction(tx).await.unwrap();
+
+    let account = context
+        .banks_client
+        .get_account(mint_account.pubkey())
+        .await
+        .unwrap();
+
+    assert!(account.is_some());
+
+    let account = account.unwrap();
+    let account = spl_token::state::Mint::unpack(&account.data).unwrap();
+
+    assert!(account.mint_authority.is_none());
+
+    // When we withdraw the excess lamports with no authority.
+
+    let destination = Pubkey::new_unique();
+
+    let mut withdraw_ix = spl_token_2022::instruction::withdraw_excess_lamports(
+        &spl_token_2022::ID,
+        &account_pubkey,
+        &destination,
+        &mint_account.pubkey(),
+        &[],
+    )
+    .unwrap();
+    // Switches the program id to the token program.
+    withdraw_ix.program_id = token_program;
+
+    let tx = Transaction::new_signed_with_payer(
+        &[withdraw_ix],
+        Some(&context.payer.pubkey()),
+        &[&context.payer, &mint_account],
+        context.last_blockhash,
+    );
+    context.banks_client.process_transaction(tx).await.unwrap();
+
+    // Then the destination account has the excess lamports.
+
+    let destination = context.banks_client.get_account(destination).await.unwrap();
+
+    assert!(destination.is_some());
+
+    let destination = destination.unwrap();
+    assert_eq!(destination.lamports, excess_lamports);
+}
+
+#[test_case::test_case(TOKEN_PROGRAM_ID ; "p-token")]
+#[tokio::test]
+async fn fail_withdraw_excess_lamports_from_mint_with_mint_as_signer(token_program: Pubkey) {
+    let context = ProgramTest::new("pinocchio_token_program", TOKEN_PROGRAM_ID, None)
+        .start_with_context()
+        .await;
+
+    let excess_lamports = 4_000_000_000_000;
+
+    // Given a mint authority, freeze authority and an account keypair.
+
+    let mint_authority = Keypair::new();
+    let freeze_authority = Pubkey::new_unique();
+    let mint_account = Keypair::new();
+    let account_pubkey = mint_account.pubkey();
+
+    let account_size = size_of::<Mint>();
+    let rent = context.banks_client.get_rent().await.unwrap();
+
+    let mut initialize_ix = spl_token::instruction::initialize_mint(
+        &spl_token::ID,
+        &mint_account.pubkey(),
+        &mint_authority.pubkey(),
+        Some(&freeze_authority),
+        0,
+    )
+    .unwrap();
+    // Switches the program id to the token program.
+    initialize_ix.program_id = token_program;
+
+    // And we initialize a mint account with excess lamports.
+
+    let instructions = vec![
+        system_instruction::create_account(
+            &context.payer.pubkey(),
+            &mint_account.pubkey(),
+            rent.minimum_balance(account_size) + excess_lamports,
+            account_size as u64,
+            &token_program,
+        ),
+        initialize_ix,
+    ];
+
+    let tx = Transaction::new_signed_with_payer(
+        &instructions,
+        Some(&context.payer.pubkey()),
+        &[&context.payer, &mint_account],
+        context.last_blockhash,
+    );
+    context.banks_client.process_transaction(tx).await.unwrap();
+
+    let account = context
+        .banks_client
+        .get_account(mint_account.pubkey())
+        .await
+        .unwrap();
+
+    assert!(account.is_some());
+
+    let account = account.unwrap();
+    assert_eq!(
+        account.lamports,
+        rent.minimum_balance(account_size) + excess_lamports
+    );
+
+    // When we try to withdraw the excess lamports with the mint as authority.
+
+    let destination = Pubkey::new_unique();
+
+    let mut withdraw_ix = spl_token_2022::instruction::withdraw_excess_lamports(
+        &spl_token_2022::ID,
+        &account_pubkey,
+        &destination,
+        &mint_account.pubkey(),
+        &[],
+    )
+    .unwrap();
+    // Switches the program id to the token program.
+    withdraw_ix.program_id = token_program;
+
+    let tx = Transaction::new_signed_with_payer(
+        &[withdraw_ix],
+        Some(&context.payer.pubkey()),
+        &[&context.payer, &mint_account],
+        context.last_blockhash,
+    );
+    let error = context
+        .banks_client
+        .process_transaction(tx)
+        .await
+        .unwrap_err();
+
+    // Then we expect an error.
+
+    assert_matches!(
+        error,
+        BanksClientError::TransactionError(TransactionError::InstructionError(
+            _,
+            InstructionError::Custom(4) // TokenError::OwnerMismatch
+        ))
+    );
+}
+
+#[test_case::test_case(TOKEN_PROGRAM_ID ; "p-token")]
+#[tokio::test]
+async fn fail_withdraw_excess_lamports_from_mint_with_no_authority(token_program: Pubkey) {
+    let context = ProgramTest::new("pinocchio_token_program", TOKEN_PROGRAM_ID, None)
+        .start_with_context()
+        .await;
+
+    let excess_lamports = 4_000_000_000_000;
+
+    // Given a mint authority, freeze authority and an account keypair.
+
+    let mint_authority = Keypair::new();
+    let freeze_authority = Pubkey::new_unique();
+    let mint_account = Keypair::new();
+    let account_pubkey = mint_account.pubkey();
+
+    let account_size = size_of::<Mint>();
+    let rent = context.banks_client.get_rent().await.unwrap();
+
+    let mut initialize_ix = spl_token::instruction::initialize_mint(
+        &spl_token::ID,
+        &mint_account.pubkey(),
+        &mint_authority.pubkey(),
+        Some(&freeze_authority),
+        0,
+    )
+    .unwrap();
+    // Switches the program id to the token program.
+    initialize_ix.program_id = token_program;
+
+    // And we initialize a mint account with excess lamports.
+
+    let instructions = vec![
+        system_instruction::create_account(
+            &context.payer.pubkey(),
+            &mint_account.pubkey(),
+            rent.minimum_balance(account_size) + excess_lamports,
+            account_size as u64,
+            &token_program,
+        ),
+        initialize_ix,
+    ];
+
+    let tx = Transaction::new_signed_with_payer(
+        &instructions,
+        Some(&context.payer.pubkey()),
+        &[&context.payer, &mint_account],
+        context.last_blockhash,
+    );
+    context.banks_client.process_transaction(tx).await.unwrap();
+
+    let account = context
+        .banks_client
+        .get_account(mint_account.pubkey())
+        .await
+        .unwrap();
+
+    assert!(account.is_some());
+
+    let account = account.unwrap();
+    assert_eq!(
+        account.lamports,
+        rent.minimum_balance(account_size) + excess_lamports
+    );
+
+    // And we remove the mint authority.
+
+    let mut set_authority_ix = spl_token::instruction::set_authority(
+        &spl_token::ID,
+        &mint_account.pubkey(),
+        None,
+        spl_token::instruction::AuthorityType::MintTokens,
+        &mint_authority.pubkey(),
+        &[&mint_authority.pubkey()],
+    )
+    .unwrap();
+    // Switches the program id to the token program.
+    set_authority_ix.program_id = token_program;
+
+    let tx = Transaction::new_signed_with_payer(
+        &[set_authority_ix],
+        Some(&context.payer.pubkey()),
+        &[&context.payer, &mint_authority],
+        context.last_blockhash,
+    );
+    context.banks_client.process_transaction(tx).await.unwrap();
+
+    let account = context
+        .banks_client
+        .get_account(mint_account.pubkey())
+        .await
+        .unwrap();
+
+    assert!(account.is_some());
+
+    let account = account.unwrap();
+    let account = spl_token::state::Mint::unpack(&account.data).unwrap();
+
+    assert!(account.mint_authority.is_none());
+
+    // When we try to withdraw the excess lamports with the "old" mint authority.
+
+    let destination = Pubkey::new_unique();
+
+    let mut withdraw_ix = spl_token_2022::instruction::withdraw_excess_lamports(
+        &spl_token_2022::ID,
+        &account_pubkey,
+        &destination,
+        &mint_authority.pubkey(),
+        &[],
+    )
+    .unwrap();
+    // Switches the program id to the token program.
+    withdraw_ix.program_id = token_program;
+
+    let tx = Transaction::new_signed_with_payer(
+        &[withdraw_ix],
+        Some(&context.payer.pubkey()),
+        &[&context.payer, &mint_authority],
+        context.last_blockhash,
+    );
+    let error = context
+        .banks_client
+        .process_transaction(tx)
+        .await
+        .unwrap_err();
+
+    // Then the destination account has the excess lamports.
+
+    assert_matches!(
+        error,
+        BanksClientError::TransactionError(TransactionError::InstructionError(
+            _,
+            InstructionError::Custom(15) // TokenError::AuthorityTypeNotSupported
         ))
     );
 }

--- a/p-token/tests/withdraw_excess_lamports.rs
+++ b/p-token/tests/withdraw_excess_lamports.rs
@@ -1123,7 +1123,7 @@ async fn fail_withdraw_excess_lamports_from_mint_with_no_authority(token_program
         .await
         .unwrap_err();
 
-    // Then the destination account has the excess lamports.
+    // Then we expect an error.
 
     assert_matches!(
         error,

--- a/p-token/tests/withdraw_excess_lamports.rs
+++ b/p-token/tests/withdraw_excess_lamports.rs
@@ -895,7 +895,9 @@ async fn withdraw_excess_lamports_from_mint_with_no_authority(token_program: Pub
 
 #[test_case::test_case(TOKEN_PROGRAM_ID ; "p-token")]
 #[tokio::test]
-async fn fail_withdraw_excess_lamports_from_mint_with_mint_as_signer(token_program: Pubkey) {
+async fn fail_withdraw_excess_lamports_from_mint_with_authority_and_mint_as_signer(
+    token_program: Pubkey,
+) {
     let context = ProgramTest::new("pinocchio_token_program", TOKEN_PROGRAM_ID, None)
         .start_with_context()
         .await;
@@ -998,7 +1000,9 @@ async fn fail_withdraw_excess_lamports_from_mint_with_mint_as_signer(token_progr
 
 #[test_case::test_case(TOKEN_PROGRAM_ID ; "p-token")]
 #[tokio::test]
-async fn fail_withdraw_excess_lamports_from_mint_with_no_authority(token_program: Pubkey) {
+async fn fail_withdraw_excess_lamports_from_mint_with_no_authority_and_authority_signer(
+    token_program: Pubkey,
+) {
     let context = ProgramTest::new("pinocchio_token_program", TOKEN_PROGRAM_ID, None)
         .start_with_context()
         .await;

--- a/p-token/tests/withdraw_excess_lamports.rs
+++ b/p-token/tests/withdraw_excess_lamports.rs
@@ -18,9 +18,8 @@ use {
     std::mem::size_of,
 };
 
-#[test_case::test_case(TOKEN_PROGRAM_ID ; "p-token")]
 #[tokio::test]
-async fn withdraw_excess_lamports_from_mint(token_program: Pubkey) {
+async fn withdraw_excess_lamports_from_mint() {
     let context = ProgramTest::new("pinocchio_token_program", TOKEN_PROGRAM_ID, None)
         .start_with_context()
         .await;
@@ -37,7 +36,7 @@ async fn withdraw_excess_lamports_from_mint(token_program: Pubkey) {
     let account_size = size_of::<Mint>();
     let rent = context.banks_client.get_rent().await.unwrap();
 
-    let mut initialize_ix = spl_token::instruction::initialize_mint(
+    let initialize_ix = spl_token::instruction::initialize_mint(
         &spl_token::ID,
         &account.pubkey(),
         &mint_authority.pubkey(),
@@ -45,8 +44,6 @@ async fn withdraw_excess_lamports_from_mint(token_program: Pubkey) {
         0,
     )
     .unwrap();
-    // Switches the program id to the token program.
-    initialize_ix.program_id = token_program;
 
     // And we initialize a mint account with excess lamports.
 
@@ -56,7 +53,7 @@ async fn withdraw_excess_lamports_from_mint(token_program: Pubkey) {
             &account.pubkey(),
             rent.minimum_balance(account_size) + excess_lamports,
             account_size as u64,
-            &token_program,
+            &TOKEN_PROGRAM_ID,
         ),
         initialize_ix,
     ];
@@ -96,7 +93,7 @@ async fn withdraw_excess_lamports_from_mint(token_program: Pubkey) {
     )
     .unwrap();
     // Switches the program id to the token program.
-    withdraw_ix.program_id = token_program;
+    withdraw_ix.program_id = TOKEN_PROGRAM_ID;
 
     let tx = Transaction::new_signed_with_payer(
         &[withdraw_ix],
@@ -116,9 +113,8 @@ async fn withdraw_excess_lamports_from_mint(token_program: Pubkey) {
     assert_eq!(destination.lamports, excess_lamports);
 }
 
-#[test_case::test_case(TOKEN_PROGRAM_ID ; "p-token")]
 #[tokio::test]
-async fn withdraw_excess_lamports_from_account(token_program: Pubkey) {
+async fn withdraw_excess_lamports_from_account() {
     let mut context = ProgramTest::new("pinocchio_token_program", TOKEN_PROGRAM_ID, None)
         .start_with_context()
         .await;
@@ -134,7 +130,7 @@ async fn withdraw_excess_lamports_from_account(token_program: Pubkey) {
         &mut context,
         mint_authority,
         Some(freeze_authority),
-        &token_program,
+        &TOKEN_PROGRAM_ID,
     )
     .await
     .unwrap();
@@ -148,15 +144,13 @@ async fn withdraw_excess_lamports_from_account(token_program: Pubkey) {
     let account_size = size_of::<Account>();
     let rent = context.banks_client.get_rent().await.unwrap();
 
-    let mut initialize_ix = spl_token::instruction::initialize_account(
+    let initialize_ix = spl_token::instruction::initialize_account(
         &spl_token::ID,
         &account.pubkey(),
         &mint,
         &owner.pubkey(),
     )
     .unwrap();
-    // Switches the program id to the token program.
-    initialize_ix.program_id = token_program;
 
     // When a new mint account is created and initialized.
 
@@ -166,7 +160,7 @@ async fn withdraw_excess_lamports_from_account(token_program: Pubkey) {
             &account.pubkey(),
             rent.minimum_balance(account_size) + excess_lamports,
             account_size as u64,
-            &token_program,
+            &TOKEN_PROGRAM_ID,
         ),
         initialize_ix,
     ];
@@ -206,7 +200,7 @@ async fn withdraw_excess_lamports_from_account(token_program: Pubkey) {
     )
     .unwrap();
     // Switches the program id to the token program.
-    withdraw_ix.program_id = token_program;
+    withdraw_ix.program_id = TOKEN_PROGRAM_ID;
 
     let tx = Transaction::new_signed_with_payer(
         &[withdraw_ix],
@@ -226,9 +220,8 @@ async fn withdraw_excess_lamports_from_account(token_program: Pubkey) {
     assert_eq!(destination.lamports, excess_lamports);
 }
 
-#[test_case::test_case(TOKEN_PROGRAM_ID ; "p-token")]
 #[tokio::test]
-async fn withdraw_excess_lamports_from_multisig(token_program: Pubkey) {
+async fn withdraw_excess_lamports_from_multisig() {
     let context = ProgramTest::new("pinocchio_token_program", TOKEN_PROGRAM_ID, None)
         .start_with_context()
         .await;
@@ -249,15 +242,13 @@ async fn withdraw_excess_lamports_from_multisig(token_program: Pubkey) {
     let rent = context.banks_client.get_rent().await.unwrap();
     let account_size = size_of::<Multisig>();
 
-    let mut initialize_ix = spl_token::instruction::initialize_multisig(
+    let initialize_ix = spl_token::instruction::initialize_multisig(
         &spl_token::ID,
         &multisig.pubkey(),
         &signers,
         3,
     )
     .unwrap();
-    // Switches the program id to the token program.
-    initialize_ix.program_id = token_program;
 
     // And we initialize the multisig account.
 
@@ -267,7 +258,7 @@ async fn withdraw_excess_lamports_from_multisig(token_program: Pubkey) {
             &multisig.pubkey(),
             rent.minimum_balance(account_size) + excess_lamports,
             account_size as u64,
-            &token_program,
+            &TOKEN_PROGRAM_ID,
         ),
         initialize_ix,
     ];
@@ -307,7 +298,7 @@ async fn withdraw_excess_lamports_from_multisig(token_program: Pubkey) {
     )
     .unwrap();
     // Switches the program id to the token program.
-    withdraw_ix.program_id = token_program;
+    withdraw_ix.program_id = TOKEN_PROGRAM_ID;
 
     let tx = Transaction::new_signed_with_payer(
         &[withdraw_ix],
@@ -327,9 +318,8 @@ async fn withdraw_excess_lamports_from_multisig(token_program: Pubkey) {
     assert_eq!(destination.lamports, excess_lamports);
 }
 
-#[test_case::test_case(TOKEN_PROGRAM_ID ; "p-token")]
 #[tokio::test]
-async fn fail_withdraw_excess_lamports_from_mint_wrong_authority(token_program: Pubkey) {
+async fn fail_withdraw_excess_lamports_from_mint_wrong_authority() {
     let context = ProgramTest::new("pinocchio_token_program", TOKEN_PROGRAM_ID, None)
         .start_with_context()
         .await;
@@ -346,7 +336,7 @@ async fn fail_withdraw_excess_lamports_from_mint_wrong_authority(token_program: 
     let account_size = size_of::<Mint>();
     let rent = context.banks_client.get_rent().await.unwrap();
 
-    let mut initialize_ix = spl_token::instruction::initialize_mint(
+    let initialize_ix = spl_token::instruction::initialize_mint(
         &spl_token::ID,
         &account.pubkey(),
         &mint_authority.pubkey(),
@@ -354,8 +344,6 @@ async fn fail_withdraw_excess_lamports_from_mint_wrong_authority(token_program: 
         0,
     )
     .unwrap();
-    // Switches the program id to the token program.
-    initialize_ix.program_id = token_program;
 
     // And we initialize a mint account with excess lamports.
 
@@ -365,7 +353,7 @@ async fn fail_withdraw_excess_lamports_from_mint_wrong_authority(token_program: 
             &account.pubkey(),
             rent.minimum_balance(account_size) + excess_lamports,
             account_size as u64,
-            &token_program,
+            &TOKEN_PROGRAM_ID,
         ),
         initialize_ix,
     ];
@@ -406,7 +394,7 @@ async fn fail_withdraw_excess_lamports_from_mint_wrong_authority(token_program: 
     )
     .unwrap();
     // Switches the program id to the token program.
-    withdraw_ix.program_id = token_program;
+    withdraw_ix.program_id = TOKEN_PROGRAM_ID;
 
     let tx = Transaction::new_signed_with_payer(
         &[withdraw_ix],
@@ -431,9 +419,8 @@ async fn fail_withdraw_excess_lamports_from_mint_wrong_authority(token_program: 
     );
 }
 
-#[test_case::test_case(TOKEN_PROGRAM_ID ; "p-token")]
 #[tokio::test]
-async fn fail_withdraw_excess_lamports_from_account_wrong_authority(token_program: Pubkey) {
+async fn fail_withdraw_excess_lamports_from_account_wrong_authority() {
     let mut context = ProgramTest::new("pinocchio_token_program", TOKEN_PROGRAM_ID, None)
         .start_with_context()
         .await;
@@ -449,7 +436,7 @@ async fn fail_withdraw_excess_lamports_from_account_wrong_authority(token_progra
         &mut context,
         mint_authority,
         Some(freeze_authority),
-        &token_program,
+        &TOKEN_PROGRAM_ID,
     )
     .await
     .unwrap();
@@ -463,15 +450,13 @@ async fn fail_withdraw_excess_lamports_from_account_wrong_authority(token_progra
     let account_size = size_of::<Account>();
     let rent = context.banks_client.get_rent().await.unwrap();
 
-    let mut initialize_ix = spl_token::instruction::initialize_account(
+    let initialize_ix = spl_token::instruction::initialize_account(
         &spl_token::ID,
         &account.pubkey(),
         &mint,
         &owner.pubkey(),
     )
     .unwrap();
-    // Switches the program id to the token program.
-    initialize_ix.program_id = token_program;
 
     // When a new mint account is created and initialized.
 
@@ -481,7 +466,7 @@ async fn fail_withdraw_excess_lamports_from_account_wrong_authority(token_progra
             &account.pubkey(),
             rent.minimum_balance(account_size) + excess_lamports,
             account_size as u64,
-            &token_program,
+            &TOKEN_PROGRAM_ID,
         ),
         initialize_ix,
     ];
@@ -522,7 +507,7 @@ async fn fail_withdraw_excess_lamports_from_account_wrong_authority(token_progra
     )
     .unwrap();
     // Switches the program id to the token program.
-    withdraw_ix.program_id = token_program;
+    withdraw_ix.program_id = TOKEN_PROGRAM_ID;
 
     let tx = Transaction::new_signed_with_payer(
         &[withdraw_ix],
@@ -547,9 +532,8 @@ async fn fail_withdraw_excess_lamports_from_account_wrong_authority(token_progra
     );
 }
 
-#[test_case::test_case(TOKEN_PROGRAM_ID ; "p-token")]
 #[tokio::test]
-async fn fail_withdraw_excess_lamports_from_multisig_wrong_authority(token_program: Pubkey) {
+async fn fail_withdraw_excess_lamports_from_multisig_wrong_authority() {
     let context = ProgramTest::new("pinocchio_token_program", TOKEN_PROGRAM_ID, None)
         .start_with_context()
         .await;
@@ -570,15 +554,13 @@ async fn fail_withdraw_excess_lamports_from_multisig_wrong_authority(token_progr
     let rent = context.banks_client.get_rent().await.unwrap();
     let account_size = size_of::<Multisig>();
 
-    let mut initialize_ix = spl_token::instruction::initialize_multisig(
+    let initialize_ix = spl_token::instruction::initialize_multisig(
         &spl_token::ID,
         &multisig.pubkey(),
         &signers,
         3,
     )
     .unwrap();
-    // Switches the program id to the token program.
-    initialize_ix.program_id = token_program;
 
     // And we initialize the multisig account.
 
@@ -588,7 +570,7 @@ async fn fail_withdraw_excess_lamports_from_multisig_wrong_authority(token_progr
             &multisig.pubkey(),
             rent.minimum_balance(account_size) + excess_lamports,
             account_size as u64,
-            &token_program,
+            &TOKEN_PROGRAM_ID,
         ),
         initialize_ix,
     ];
@@ -629,7 +611,7 @@ async fn fail_withdraw_excess_lamports_from_multisig_wrong_authority(token_progr
     )
     .unwrap();
     // Switches the program id to the token program.
-    withdraw_ix.program_id = token_program;
+    withdraw_ix.program_id = TOKEN_PROGRAM_ID;
 
     let tx = Transaction::new_signed_with_payer(
         &[withdraw_ix],
@@ -654,9 +636,8 @@ async fn fail_withdraw_excess_lamports_from_multisig_wrong_authority(token_progr
     );
 }
 
-#[test_case::test_case(TOKEN_PROGRAM_ID ; "p-token")]
 #[tokio::test]
-async fn fail_withdraw_excess_lamports_from_multisig_missing_signer(token_program: Pubkey) {
+async fn fail_withdraw_excess_lamports_from_multisig_missing_signer() {
     let context = ProgramTest::new("pinocchio_token_program", TOKEN_PROGRAM_ID, None)
         .start_with_context()
         .await;
@@ -677,15 +658,13 @@ async fn fail_withdraw_excess_lamports_from_multisig_missing_signer(token_progra
     let rent = context.banks_client.get_rent().await.unwrap();
     let account_size = size_of::<Multisig>();
 
-    let mut initialize_ix = spl_token::instruction::initialize_multisig(
+    let initialize_ix = spl_token::instruction::initialize_multisig(
         &spl_token::ID,
         &multisig.pubkey(),
         &signers,
         3,
     )
     .unwrap();
-    // Switches the program id to the token program.
-    initialize_ix.program_id = token_program;
 
     // And we initialize the multisig account.
 
@@ -695,7 +674,7 @@ async fn fail_withdraw_excess_lamports_from_multisig_missing_signer(token_progra
             &multisig.pubkey(),
             rent.minimum_balance(account_size) + excess_lamports,
             account_size as u64,
-            &token_program,
+            &TOKEN_PROGRAM_ID,
         ),
         initialize_ix,
     ];
@@ -735,7 +714,7 @@ async fn fail_withdraw_excess_lamports_from_multisig_missing_signer(token_progra
     )
     .unwrap();
     // Switches the program id to the token program.
-    withdraw_ix.program_id = token_program;
+    withdraw_ix.program_id = TOKEN_PROGRAM_ID;
 
     let tx = Transaction::new_signed_with_payer(
         &[withdraw_ix],
@@ -760,9 +739,8 @@ async fn fail_withdraw_excess_lamports_from_multisig_missing_signer(token_progra
     );
 }
 
-#[test_case::test_case(TOKEN_PROGRAM_ID ; "p-token")]
 #[tokio::test]
-async fn withdraw_excess_lamports_from_mint_with_no_authority(token_program: Pubkey) {
+async fn withdraw_excess_lamports_from_mint_with_no_authority() {
     let context = ProgramTest::new("pinocchio_token_program", TOKEN_PROGRAM_ID, None)
         .start_with_context()
         .await;
@@ -779,7 +757,7 @@ async fn withdraw_excess_lamports_from_mint_with_no_authority(token_program: Pub
     let account_size = size_of::<Mint>();
     let rent = context.banks_client.get_rent().await.unwrap();
 
-    let mut initialize_ix = spl_token::instruction::initialize_mint(
+    let initialize_ix = spl_token::instruction::initialize_mint(
         &spl_token::ID,
         &mint_account.pubkey(),
         &mint_authority.pubkey(),
@@ -787,8 +765,6 @@ async fn withdraw_excess_lamports_from_mint_with_no_authority(token_program: Pub
         0,
     )
     .unwrap();
-    // Switches the program id to the token program.
-    initialize_ix.program_id = token_program;
 
     // And we initialize a mint account with excess lamports.
 
@@ -798,7 +774,7 @@ async fn withdraw_excess_lamports_from_mint_with_no_authority(token_program: Pub
             &mint_account.pubkey(),
             rent.minimum_balance(account_size) + excess_lamports,
             account_size as u64,
-            &token_program,
+            &TOKEN_PROGRAM_ID,
         ),
         initialize_ix,
     ];
@@ -827,7 +803,7 @@ async fn withdraw_excess_lamports_from_mint_with_no_authority(token_program: Pub
 
     // And we remove the mint authority.
 
-    let mut set_authority_ix = spl_token::instruction::set_authority(
+    let set_authority_ix = spl_token::instruction::set_authority(
         &spl_token::ID,
         &mint_account.pubkey(),
         None,
@@ -836,8 +812,6 @@ async fn withdraw_excess_lamports_from_mint_with_no_authority(token_program: Pub
         &[&mint_authority.pubkey()],
     )
     .unwrap();
-    // Switches the program id to the token program.
-    set_authority_ix.program_id = token_program;
 
     let tx = Transaction::new_signed_with_payer(
         &[set_authority_ix],
@@ -873,7 +847,7 @@ async fn withdraw_excess_lamports_from_mint_with_no_authority(token_program: Pub
     )
     .unwrap();
     // Switches the program id to the token program.
-    withdraw_ix.program_id = token_program;
+    withdraw_ix.program_id = TOKEN_PROGRAM_ID;
 
     let tx = Transaction::new_signed_with_payer(
         &[withdraw_ix],
@@ -893,11 +867,8 @@ async fn withdraw_excess_lamports_from_mint_with_no_authority(token_program: Pub
     assert_eq!(destination.lamports, excess_lamports);
 }
 
-#[test_case::test_case(TOKEN_PROGRAM_ID ; "p-token")]
 #[tokio::test]
-async fn fail_withdraw_excess_lamports_from_mint_with_authority_and_mint_as_signer(
-    token_program: Pubkey,
-) {
+async fn fail_withdraw_excess_lamports_from_mint_with_authority_and_mint_as_signer() {
     let context = ProgramTest::new("pinocchio_token_program", TOKEN_PROGRAM_ID, None)
         .start_with_context()
         .await;
@@ -914,7 +885,7 @@ async fn fail_withdraw_excess_lamports_from_mint_with_authority_and_mint_as_sign
     let account_size = size_of::<Mint>();
     let rent = context.banks_client.get_rent().await.unwrap();
 
-    let mut initialize_ix = spl_token::instruction::initialize_mint(
+    let initialize_ix = spl_token::instruction::initialize_mint(
         &spl_token::ID,
         &mint_account.pubkey(),
         &mint_authority.pubkey(),
@@ -922,8 +893,6 @@ async fn fail_withdraw_excess_lamports_from_mint_with_authority_and_mint_as_sign
         0,
     )
     .unwrap();
-    // Switches the program id to the token program.
-    initialize_ix.program_id = token_program;
 
     // And we initialize a mint account with excess lamports.
 
@@ -933,7 +902,7 @@ async fn fail_withdraw_excess_lamports_from_mint_with_authority_and_mint_as_sign
             &mint_account.pubkey(),
             rent.minimum_balance(account_size) + excess_lamports,
             account_size as u64,
-            &token_program,
+            &TOKEN_PROGRAM_ID,
         ),
         initialize_ix,
     ];
@@ -973,7 +942,7 @@ async fn fail_withdraw_excess_lamports_from_mint_with_authority_and_mint_as_sign
     )
     .unwrap();
     // Switches the program id to the token program.
-    withdraw_ix.program_id = token_program;
+    withdraw_ix.program_id = TOKEN_PROGRAM_ID;
 
     let tx = Transaction::new_signed_with_payer(
         &[withdraw_ix],
@@ -998,11 +967,8 @@ async fn fail_withdraw_excess_lamports_from_mint_with_authority_and_mint_as_sign
     );
 }
 
-#[test_case::test_case(TOKEN_PROGRAM_ID ; "p-token")]
 #[tokio::test]
-async fn fail_withdraw_excess_lamports_from_mint_with_no_authority_and_authority_signer(
-    token_program: Pubkey,
-) {
+async fn fail_withdraw_excess_lamports_from_mint_with_no_authority_and_authority_signer() {
     let context = ProgramTest::new("pinocchio_token_program", TOKEN_PROGRAM_ID, None)
         .start_with_context()
         .await;
@@ -1019,7 +985,7 @@ async fn fail_withdraw_excess_lamports_from_mint_with_no_authority_and_authority
     let account_size = size_of::<Mint>();
     let rent = context.banks_client.get_rent().await.unwrap();
 
-    let mut initialize_ix = spl_token::instruction::initialize_mint(
+    let initialize_ix = spl_token::instruction::initialize_mint(
         &spl_token::ID,
         &mint_account.pubkey(),
         &mint_authority.pubkey(),
@@ -1027,8 +993,6 @@ async fn fail_withdraw_excess_lamports_from_mint_with_no_authority_and_authority
         0,
     )
     .unwrap();
-    // Switches the program id to the token program.
-    initialize_ix.program_id = token_program;
 
     // And we initialize a mint account with excess lamports.
 
@@ -1038,7 +1002,7 @@ async fn fail_withdraw_excess_lamports_from_mint_with_no_authority_and_authority
             &mint_account.pubkey(),
             rent.minimum_balance(account_size) + excess_lamports,
             account_size as u64,
-            &token_program,
+            &TOKEN_PROGRAM_ID,
         ),
         initialize_ix,
     ];
@@ -1067,7 +1031,7 @@ async fn fail_withdraw_excess_lamports_from_mint_with_no_authority_and_authority
 
     // And we remove the mint authority.
 
-    let mut set_authority_ix = spl_token::instruction::set_authority(
+    let set_authority_ix = spl_token::instruction::set_authority(
         &spl_token::ID,
         &mint_account.pubkey(),
         None,
@@ -1076,8 +1040,6 @@ async fn fail_withdraw_excess_lamports_from_mint_with_no_authority_and_authority
         &[&mint_authority.pubkey()],
     )
     .unwrap();
-    // Switches the program id to the token program.
-    set_authority_ix.program_id = token_program;
 
     let tx = Transaction::new_signed_with_payer(
         &[set_authority_ix],
@@ -1113,7 +1075,7 @@ async fn fail_withdraw_excess_lamports_from_mint_with_no_authority_and_authority
     )
     .unwrap();
     // Switches the program id to the token program.
-    withdraw_ix.program_id = token_program;
+    withdraw_ix.program_id = TOKEN_PROGRAM_ID;
 
     let tx = Transaction::new_signed_with_payer(
         &[withdraw_ix],


### PR DESCRIPTION
### Problem

The tests on p-token used to run both SPL Token and p-token using the `test_case` crate as a "conformance" test. Since it now uses fixtures for that, the `test_case` annotation is redundant.

### Solution

Clean-up the tests, removing the `test_case` annotation and dependency.