### PR TITLE
perf: p-token optimize pubkey cmp

### DIFF
--- a/p-token/src/processor/close_account.rs
+++ b/p-token/src/processor/close_account.rs
@@ -1,5 +1,5 @@
 use {
-    super::validate_owner,
+    super::{pubkeys_eq, validate_owner},
     pinocchio::{account_info::AccountInfo, program_error::ProgramError, ProgramResult},
     spl_token_interface::{
         error::TokenError,
@@ -38,7 +38,7 @@ pub fn process_close_account(accounts: &[AccountInfo]) -> ProgramResult {
 
         if !source_account.is_owned_by_system_program_or_incinerator() {
             validate_owner(authority, authority_info, remaining)?;
-        } else if destination_account_info.key() != &INCINERATOR_ID {
+        } else if !pubkeys_eq(destination_account_info.key(), &INCINERATOR_ID) {
             return Err(ProgramError::InvalidAccountData);
         }
     }

--- a/p-token/src/processor/shared/approve.rs
+++ b/p-token/src/processor/shared/approve.rs
@@ -1,5 +1,5 @@
 use {
-    crate::processor::validate_owner,
+    crate::processor::{pubkeys_eq, validate_owner},
     pinocchio::{account_info::AccountInfo, program_error::ProgramError, ProgramResult},
     spl_token_interface::{
         error::TokenError,
@@ -56,7 +56,7 @@ pub fn process_approve(
     }
 
     if let Some((mint_info, expected_decimals)) = expected_mint_info {
-        if mint_info.key() != &source_account.mint {
+        if !pubkeys_eq(mint_info.key(), &source_account.mint) {
             return Err(TokenError::MintMismatch.into());
         }
 

--- a/p-token/src/processor/shared/burn.rs
+++ b/p-token/src/processor/shared/burn.rs
@@ -1,5 +1,5 @@
 use {
-    crate::processor::{check_account_owner, validate_owner},
+    crate::processor::{check_account_owner, pubkeys_eq, validate_owner},
     pinocchio::{account_info::AccountInfo, program_error::ProgramError, ProgramResult},
     spl_token_interface::{
         error::TokenError,
@@ -41,7 +41,7 @@ pub fn process_burn(
         .checked_sub(amount)
         .ok_or(TokenError::InsufficientFunds)?;
 
-    if mint_info.key() != &source_account.mint {
+    if !pubkeys_eq(mint_info.key(), &source_account.mint) {
         return Err(TokenError::MintMismatch.into());
     }
 
@@ -53,7 +53,7 @@ pub fn process_burn(
 
     if !source_account.is_owned_by_system_program_or_incinerator() {
         match source_account.delegate() {
-            Some(delegate) if authority_info.key() == delegate => {
+            Some(delegate) if pubkeys_eq(authority_info.key(), delegate) => {
                 validate_owner(delegate, authority_info, remaining)?;
 
                 let delegated_amount = source_account

--- a/p-token/src/processor/shared/mint_to.rs
+++ b/p-token/src/processor/shared/mint_to.rs
@@ -1,5 +1,5 @@
 use {
-    crate::processor::{check_account_owner, validate_owner},
+    crate::processor::{check_account_owner, pubkeys_eq, validate_owner},
     pinocchio::{account_info::AccountInfo, program_error::ProgramError, ProgramResult},
     spl_token_interface::{
         error::TokenError,
@@ -33,7 +33,7 @@ pub fn process_mint_to(
         return Err(TokenError::NativeNotSupported.into());
     }
 
-    if mint_info.key() != &destination_account.mint {
+    if !pubkeys_eq(mint_info.key(), &destination_account.mint) {
         return Err(TokenError::MintMismatch.into());
     }
 

--- a/p-token/src/processor/shared/toggle_account_state.rs
+++ b/p-token/src/processor/shared/toggle_account_state.rs
@@ -1,5 +1,5 @@
 use {
-    crate::processor::validate_owner,
+    crate::processor::{pubkeys_eq, validate_owner},
     pinocchio::{account_info::AccountInfo, program_error::ProgramError, ProgramResult},
     spl_token_interface::{
         error::TokenError,
@@ -24,7 +24,7 @@ pub fn process_toggle_account_state(accounts: &[AccountInfo], freeze: bool) -> P
     if source_account.is_native() {
         return Err(TokenError::NativeNotSupported.into());
     }
-    if mint_info.key() != &source_account.mint {
+    if !pubkeys_eq(mint_info.key(), &source_account.mint) {
         return Err(TokenError::MintMismatch.into());
     }
 


### PR DESCRIPTION
### Issue
- `p-token` uses `partial_eq` to compare pubkeys which is not optimal.
- `spl-token` uses `sol_memcmp` which is better than  `partial_eq`  ([program/src/processor.rs](https://github.com/solana-program/token/blob/8921377ea5cd109d49a888b8ef57f041d6f20ce1/program/src/processor.rs#L978)).
- A custom `pubkey_eq` implementation can improve performance of many `p-token` instructions by 10s of CU see table.

  | Instruction       | p-token main | sol_memcmp | pubkey_eq |  Savings (pubkey_eq - main)|
  |-------------------|--------------|------------|-------------------|--------------------|
  | InitializeMint    | 148 CU       | 144 CU     | 143 CU            | -5 CU              |
  | InitializeAccount | 228 CU       | 227 CU     | 225 CU            | -3 CU              |
  | Mint | 187 CU       | 174 CU     | 148 CU            | -39 CU              |
  | Transfer          | 189 CU     | 175 CU | 144 CU        |  -45 CU      |
  | TransferChecked   |  256 CU   | - |186 CU         |  -70 CU      |
  | Batch   | 1,691 CU    | - | 1,598 CU          | -93 CU |

To reproduce CU measurements, see tx logs by `transfer` , `transfer_checked`, `batch` tests in branches:
-  [main](https://github.com/solana-program/token)
- [jorrit/bench-sol_memcmp](https://github.com/ananas-block/token/tree/jorrit/bench-sol_memcmp)
-  [jorrit/perf-optimize-pubkey-eq](https://github.com/ananas-block/token/tree/jorrit/perf-optimize-pubkey-eq)

### Changes:
- introduce `pubkey_eq`, cast 32 byte arrays to 4 u64 chunks, compare in a loop and exit early on unequal
- replace pubkey comparisons with `pubkey_eq`



### Notes:
- u64 chunks perform significantly better than u16, u32, u128 chunks [see this repo](https://github.com/ananas-block/byte-array-cmp?tab=readme-ov-file#simd-iterator-integer-type-variants-1000-iterations-not-found).
- I have only run `transfer`, `transfer_checked`, and `batch`  tests (building all tests doesn't work with 32gb ram). It is unlikely that performance of other instructions decreased with this change but best double check.
- Maybe it makes sense to upstream this to `pinocchio` to use it in `AccountInfo::is_owned_by`.
- Versions:
solana-cargo-build-sbf 2.2.15
platform-tools v1.48
rustc 1.84.1