### PR TITLE
p-token: Add unsafe to transmutable trait

### DIFF
--- a/interface/src/state/account.rs
+++ b/interface/src/state/account.rs
@@ -151,7 +151,7 @@ impl Account {
     }
 }
 
-impl Transmutable for Account {
+unsafe impl Transmutable for Account {
     const LEN: usize = core::mem::size_of::<Account>();
 }
 

--- a/interface/src/state/mint.rs
+++ b/interface/src/state/mint.rs
@@ -84,7 +84,7 @@ impl Mint {
     }
 }
 
-impl Transmutable for Mint {
+unsafe impl Transmutable for Mint {
     /// The length of the `Mint` account data.
     const LEN: usize = core::mem::size_of::<Mint>();
 }

--- a/interface/src/state/mod.rs
+++ b/interface/src/state/mod.rs
@@ -10,10 +10,12 @@ pub type COption<T> = ([u8; 4], T);
 
 /// Marker trait for types that can be cast from a raw pointer.
 ///
+/// # Safety
+///
 /// It is up to the type implementing this trait to guarantee that the cast is
 /// safe, i.e., the fields of the type are well aligned and there are no padding
 /// bytes.
-pub trait Transmutable {
+pub unsafe trait Transmutable {
     /// The length of the type.
     ///
     /// This must be equal to the size of each individual field in the type.

--- a/interface/src/state/multisig.rs
+++ b/interface/src/state/multisig.rs
@@ -38,7 +38,7 @@ impl Multisig {
     }
 }
 
-impl Transmutable for Multisig {
+unsafe impl Transmutable for Multisig {
     /// The length of the `Multisig` account data.
     const LEN: usize = core::mem::size_of::<Multisig>();
 }


### PR DESCRIPTION
### Problem

The `Transmutable` trait has memory safety implications in its implementation, but it is not marked as `unsafe`. This is problematic since undefined behaviour can result from an incorrect implementation.

### Solution

Add `unsafe` to `Transmutable` trait to make it explicit that the trait has to be carefully implemented.

cc: @d0nutptr