### PR TITLE
p-token: Use latest pinocchio crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3036,24 +3036,25 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pinocchio"
-version = "0.8.4"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c33b58567c11b07749cefbb8320ac023f3387c57807aeb8e3b1262501b6e9f0"
+checksum = "5123fe61ac87a327d434d530eaddaaf65069a37e33e5c9f798feaed29e4974c8"
 
 [[package]]
 name = "pinocchio-log"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f89f8ffd986174cefe59448295a004aaf70c3605f30de066f42d27b06188f267"
+checksum = "f266eb7ddac75ef32c42025d5cc571da4f8c9e6d5c3d70820c204d5fee72e57a"
 
 [[package]]
 name = "pinocchio-pubkey"
-version = "0.2.4"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6b20fcebc172c3cd3f54114b0241b48fa8e30893ced2eb4927aaba5e3a0ba5"
+checksum = "cb0225638cadcbebae8932cb7f49cb5da7c15c21beb19f048f05a5ca7d93f065"
 dependencies = [
  "five8_const",
  "pinocchio",
+ "sha2-const-stable",
 ]
 
 [[package]]
@@ -4049,6 +4050,12 @@ dependencies = [
  "cpufeatures",
  "digest 0.10.7",
 ]
+
+[[package]]
+name = "sha2-const-stable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f179d4e11094a893b82fff208f74d448a7512f99f5a0acbd5c679b705f83ed9"
 
 [[package]]
 name = "sha3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ consolidate-commits = false
 
 [workspace.dependencies]
 num-traits = "0.2"
-pinocchio = "0.8.4"
+pinocchio = "0.9"
 solana-instruction = "2.3.0"
 solana-program-error = "2.2.2"
 solana-program-option = "2.2.1"

--- a/interface/Cargo.toml
+++ b/interface/Cargo.toml
@@ -13,7 +13,7 @@ crate-type = ["rlib"]
 
 [dependencies]
 pinocchio = { workspace = true }
-pinocchio-pubkey = "0.2"
+pinocchio-pubkey = "0.3"
 
 [dev-dependencies]
 strum = "0.27"

--- a/p-token/Cargo.toml
+++ b/p-token/Cargo.toml
@@ -16,7 +16,7 @@ logging = []
 
 [dependencies]
 pinocchio = { workspace = true }
-pinocchio-log = { version = "0.4", default-features = false }
+pinocchio-log = { version = "0.5", default-features = false }
 spl-token-interface = { version = "^0", path = "../interface" }
 
 [dev-dependencies]


### PR DESCRIPTION
### Problem

There are newer pinocchio crates published.

### Solution

Update the pinocchio dependencies.