### PR TITLE
CI: Add "interface" as a publishable target

### DIFF
--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -10,6 +10,7 @@ on:
         type: choice
         options:
           - clients/rust
+          - interface
           - p-interface
           - program
           - p-token


### PR DESCRIPTION
#### Problem

We publish our rust crates through a manual github action, in which you need to specify which directory to publish. However, the "interface" directory is not in that list, so we can't publish the interface crate.

#### Summary of changes

Add "interface" to the list.