### PR TITLE
reuse amount validations

### DIFF
--- a/p-token/src/processor/shared/transfer.rs
+++ b/p-token/src/processor/shared/transfer.rs
@@ -171,18 +171,14 @@ pub fn process_transfer(
         if source_account.is_native() {
             // SAFETY: single mutable borrow to `source_account_info` lamports.
             let source_lamports = unsafe { source_account_info.borrow_mut_lamports_unchecked() };
-            *source_lamports = source_lamports
-                .checked_sub(amount)
-                .ok_or(TokenError::Overflow)?;
+            *source_lamports -= amount;
 
             // SAFETY: single mutable borrow to `destination_account_info` lamports; the
             // account is already validated to be different from
             // `source_account_info`.
             let destination_lamports =
                 unsafe { destination_account_info.borrow_mut_lamports_unchecked() };
-            *destination_lamports = destination_lamports
-                .checked_add(amount)
-                .ok_or(TokenError::Overflow)?;
+            *destination_lamports += amount;
         }
     }
 

--- a/p-token/src/processor/shared/transfer.rs
+++ b/p-token/src/processor/shared/transfer.rs
@@ -180,6 +180,7 @@ pub fn process_transfer(
             // `source_account_info`.
             let destination_lamports =
                 unsafe { destination_account_info.borrow_mut_lamports_unchecked() };
+            // Note: The total lamports supply is bound to `u64::MAX`.
             *destination_lamports += amount;
         }
     }

--- a/p-token/src/processor/shared/transfer.rs
+++ b/p-token/src/processor/shared/transfer.rs
@@ -171,8 +171,8 @@ pub fn process_transfer(
         if source_account.is_native() {
             // SAFETY: single mutable borrow to `source_account_info` lamports.
             let source_lamports = unsafe { source_account_info.borrow_mut_lamports_unchecked() };
-            // Note: The amount of a source token account is already validated and the `lamports`
-            //  on the account is always greater than `amount`.
+            // Note: The amount of a source token account is already validated and the
+            // `lamports` on the account is always greater than `amount`.
             *source_lamports -= amount;
 
             // SAFETY: single mutable borrow to `destination_account_info` lamports; the

--- a/p-token/src/processor/shared/transfer.rs
+++ b/p-token/src/processor/shared/transfer.rs
@@ -171,6 +171,8 @@ pub fn process_transfer(
         if source_account.is_native() {
             // SAFETY: single mutable borrow to `source_account_info` lamports.
             let source_lamports = unsafe { source_account_info.borrow_mut_lamports_unchecked() };
+            // Note: The amount of a source token account is already validated and the `lamports`
+            //  on the account is always greater than `amount`.
             *source_lamports -= amount;
 
             // SAFETY: single mutable borrow to `destination_account_info` lamports; the


### PR DESCRIPTION
### Problem

Currently, both amount and lamports are validated during a transfer involving native accounts. Since amount is already validated, it is not strictly necessary to validate lamports as well.

### Solution

Use unchecked operations when manipulating lamport values, which reduces CU consumption.