### PR TITLE
p-token: Simplify math operations

### DIFF
--- a/p-token/src/processor/close_account.rs
+++ b/p-token/src/processor/close_account.rs
@@ -11,6 +11,7 @@ use {
 };
 
 #[inline(always)]
+#[allow(clippy::arithmetic_side_effects)]
 pub fn process_close_account(accounts: &[AccountInfo]) -> ProgramResult {
     let [source_account_info, destination_account_info, authority_info, remaining @ ..] = accounts
     else {

--- a/p-token/src/processor/close_account.rs
+++ b/p-token/src/processor/close_account.rs
@@ -44,14 +44,11 @@ pub fn process_close_account(accounts: &[AccountInfo]) -> ProgramResult {
         }
     }
 
-    let destination_starting_lamports = destination_account_info.lamports();
     // SAFETY: single mutable borrow to `destination_account_info` lamports and
     // there are no "active" borrows of `source_account_info` account data.
     unsafe {
         // Moves the lamports to the destination account.
-        *destination_account_info.borrow_mut_lamports_unchecked() = destination_starting_lamports
-            .checked_add(source_account_info.lamports())
-            .ok_or(TokenError::Overflow)?;
+        *destination_account_info.borrow_mut_lamports_unchecked() += source_account_info.lamports();
         // Closes the source account.
         source_account_info.close_unchecked();
     }

--- a/p-token/src/processor/close_account.rs
+++ b/p-token/src/processor/close_account.rs
@@ -50,7 +50,9 @@ pub fn process_close_account(accounts: &[AccountInfo]) -> ProgramResult {
     unsafe {
         // Moves the lamports to the destination account.
         //
-        // Note: The total lamports supply is bound to `u64::MAX`.
+        // Note: This is safe since the runtime checks for balanced instructions
+        // before and after each CPI and instruction, and the total lamports
+        // supply is bound to `u64::MAX`.
         *destination_account_info.borrow_mut_lamports_unchecked() += source_account_info.lamports();
         // Closes the source account.
         source_account_info.close_unchecked();

--- a/p-token/src/processor/close_account.rs
+++ b/p-token/src/processor/close_account.rs
@@ -49,6 +49,8 @@ pub fn process_close_account(accounts: &[AccountInfo]) -> ProgramResult {
     // there are no "active" borrows of `source_account_info` account data.
     unsafe {
         // Moves the lamports to the destination account.
+        //
+        // Note: The total lamports supply is bound to `u64::MAX`.
         *destination_account_info.borrow_mut_lamports_unchecked() += source_account_info.lamports();
         // Closes the source account.
         source_account_info.close_unchecked();

--- a/p-token/src/processor/shared/burn.rs
+++ b/p-token/src/processor/shared/burn.rs
@@ -8,6 +8,7 @@ use {
 };
 
 #[inline(always)]
+#[allow(clippy::arithmetic_side_effects)]
 pub fn process_burn(
     accounts: &[AccountInfo],
     amount: u64,

--- a/p-token/src/processor/shared/burn.rs
+++ b/p-token/src/processor/shared/burn.rs
@@ -83,8 +83,7 @@ pub fn process_burn(
         source_account.set_amount(updated_source_amount);
         // Note: The amount of a token account is always within the range of the
         // mint supply (`u64`).
-        let mint_supply = mint.supply().checked_sub(amount).unwrap();
-        mint.set_supply(mint_supply);
+        mint.set_supply(mint.supply() - amount);
     }
 
     Ok(())

--- a/p-token/src/processor/withdraw_excess_lamports.rs
+++ b/p-token/src/processor/withdraw_excess_lamports.rs
@@ -86,13 +86,12 @@ pub fn process_withdraw_excess_lamports(accounts: &[AccountInfo]) -> ProgramResu
             source_starting_lamports - transfer_amount;
     }
 
-    let destination_starting_lamports = destination_info.lamports();
     // SAFETY: single mutable borrow to `destination_info` lamports.
     unsafe {
         // Moves the lamports to the destination account.
-        *destination_info.borrow_mut_lamports_unchecked() = destination_starting_lamports
-            .checked_add(transfer_amount)
-            .ok_or(TokenError::Overflow)?;
+        //
+        // Note: The total lamports supply is bound to `u64::MAX`.
+        *destination_info.borrow_mut_lamports_unchecked() += transfer_amount;
     }
 
     Ok(())


### PR DESCRIPTION
### Problem

Following #82, there are a few more places where math operations can be simplified since it is guaranteed that values will be within the valid limit.

### Solution

Simplify math operation, which leads to reduction in CU.

| instruction | Before | After |
|------------|-------|-------|
| burn           | 123     |  122    |
|close_account | 123  |  116 |
| burn_checked | 126 | 125 |
withdraw_excess_lamports | 292 | 284 |