### PR TITLE
audit: Update tracing-subscriber to v0.3.20

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8198,9 +8198,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.19"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
+checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
 dependencies = [
  "sharded-slab",
  "thread_local",


### PR DESCRIPTION
### Problem

CI is currently failing since there is a security advisory on `tracing-susbcriber@v0.3.19`.

### Solution 

Bmp tracing-subscriber to v0.3.20.