### PR TITLE
program: Deprecate re-exports from spl-token-interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3095,8 +3095,8 @@ dependencies = [
  "solana-system-interface",
  "solana-transaction",
  "solana-transaction-error",
- "spl-token 8.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "spl-token-2022",
+ "spl-token-2022-interface",
+ "spl-token-interface 1.0.0",
 ]
 
 [[package]]
@@ -6277,12 +6277,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-security-txt"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "468aa43b7edb1f9b7b7b686d5c3aeb6630dc1708e86e31343499dd5c4d775183"
-
-[[package]]
 name = "solana-seed-derivable"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7263,50 +7257,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "spl-elgamal-registry"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56cc66fe64651a48c8deb4793d8a5deec8f8faf19f355b9df294387bc5a36b5f"
-dependencies = [
- "bytemuck",
- "solana-account-info",
- "solana-cpi",
- "solana-instruction 2.3.0",
- "solana-msg",
- "solana-program-entrypoint",
- "solana-program-error 2.2.2",
- "solana-pubkey 2.4.0",
- "solana-rent",
- "solana-sdk-ids 2.2.1",
- "solana-security-txt",
- "solana-system-interface",
- "solana-sysvar",
- "solana-zk-sdk",
- "spl-pod",
- "spl-token-confidential-transfer-proof-extraction",
-]
-
-[[package]]
 name = "spl-generic-token"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "741a62a566d97c58d33f9ed32337ceedd4e35109a686e31b1866c5dfa56abddc"
 dependencies = [
  "bytemuck",
- "solana-pubkey 2.4.0",
-]
-
-[[package]]
-name = "spl-memo"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f09647c0974e33366efeb83b8e2daebb329f0420149e74d3a4bd2c08cf9f7cb"
-dependencies = [
- "solana-account-info",
- "solana-instruction 2.3.0",
- "solana-msg",
- "solana-program-entrypoint",
- "solana-program-error 2.2.2",
  "solana-pubkey 2.4.0",
 ]
 
@@ -7327,55 +7283,6 @@ dependencies = [
  "solana-program-option 2.2.1",
  "solana-pubkey 2.4.0",
  "solana-zk-sdk",
- "thiserror 2.0.12",
-]
-
-[[package]]
-name = "spl-program-error"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdebc8b42553070b75aa5106f071fef2eb798c64a7ec63375da4b1f058688c6"
-dependencies = [
- "num-derive",
- "num-traits",
- "solana-decode-error",
- "solana-msg",
- "solana-program-error 2.2.2",
- "spl-program-error-derive",
- "thiserror 2.0.12",
-]
-
-[[package]]
-name = "spl-program-error-derive"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a2539e259c66910d78593475540e8072f0b10f0f61d7607bbf7593899ed52d0"
-dependencies = [
- "proc-macro2",
- "quote",
- "sha2 0.10.8",
- "syn 2.0.96",
-]
-
-[[package]]
-name = "spl-tlv-account-resolution"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1408e961215688715d5a1063cbdcf982de225c45f99c82b4f7d7e1dd22b998d7"
-dependencies = [
- "bytemuck",
- "num-derive",
- "num-traits",
- "solana-account-info",
- "solana-decode-error",
- "solana-instruction 2.3.0",
- "solana-msg",
- "solana-program-error 2.2.2",
- "solana-pubkey 2.4.0",
- "spl-discriminator",
- "spl-pod",
- "spl-program-error",
- "spl-type-length-value",
  "thiserror 2.0.12",
 ]
 
@@ -7417,10 +7324,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "spl-token"
-version = "8.0.0"
+name = "spl-token-2022-interface"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053067c6a82c705004f91dae058b11b4780407e9ccd6799dc9e7d0fab5f242da"
+checksum = "62d7ae2ee6b856f8ddcbdc3b3a9f4d2141582bbe150f93e5298ee97e0251fa04"
 dependencies = [
  "arrayref",
  "bytemuck",
@@ -7428,76 +7335,22 @@ dependencies = [
  "num-traits",
  "num_enum",
  "solana-account-info",
- "solana-cpi",
  "solana-decode-error",
  "solana-instruction 2.3.0",
  "solana-msg",
- "solana-program-entrypoint",
  "solana-program-error 2.2.2",
- "solana-program-memory",
  "solana-program-option 2.2.1",
  "solana-program-pack 2.2.1",
  "solana-pubkey 2.4.0",
- "solana-rent",
  "solana-sdk-ids 2.2.1",
- "solana-sysvar",
- "thiserror 2.0.12",
-]
-
-[[package]]
-name = "spl-token-2022"
-version = "9.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707d8237d17d857246b189d0fb278797dcd7cf6219374547791b231fd35a8cc8"
-dependencies = [
- "arrayref",
- "bytemuck",
- "num-derive",
- "num-traits",
- "num_enum",
- "solana-account-info",
- "solana-clock",
- "solana-cpi",
- "solana-decode-error",
- "solana-instruction 2.3.0",
- "solana-msg",
- "solana-native-token",
- "solana-program-entrypoint",
- "solana-program-error 2.2.2",
- "solana-program-memory",
- "solana-program-option 2.2.1",
- "solana-program-pack 2.2.1",
- "solana-pubkey 2.4.0",
- "solana-rent",
- "solana-sdk-ids 2.2.1",
- "solana-security-txt",
- "solana-system-interface",
- "solana-sysvar",
  "solana-zk-sdk",
- "spl-elgamal-registry",
- "spl-memo",
  "spl-pod",
- "spl-token 8.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "spl-token-confidential-transfer-ciphertext-arithmetic",
  "spl-token-confidential-transfer-proof-extraction",
  "spl-token-confidential-transfer-proof-generation",
  "spl-token-group-interface",
  "spl-token-metadata-interface",
- "spl-transfer-hook-interface",
  "spl-type-length-value",
  "thiserror 2.0.12",
-]
-
-[[package]]
-name = "spl-token-confidential-transfer-ciphertext-arithmetic"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94ab20faf7b5edaa79acd240e0f21d5a2ef936aa99ed98f698573a2825b299c4"
-dependencies = [
- "base64 0.22.1",
- "bytemuck",
- "solana-curve25519",
- "solana-zk-sdk",
 ]
 
 [[package]]
@@ -7608,31 +7461,6 @@ dependencies = [
  "solana-pubkey 2.4.0",
  "spl-discriminator",
  "spl-pod",
- "spl-type-length-value",
- "thiserror 2.0.12",
-]
-
-[[package]]
-name = "spl-transfer-hook-interface"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7e905b849b6aba63bde8c4badac944ebb6c8e6e14817029cbe1bc16829133bd"
-dependencies = [
- "arrayref",
- "bytemuck",
- "num-derive",
- "num-traits",
- "solana-account-info",
- "solana-cpi",
- "solana-decode-error",
- "solana-instruction 2.3.0",
- "solana-msg",
- "solana-program-error 2.2.2",
- "solana-pubkey 2.4.0",
- "spl-discriminator",
- "spl-pod",
- "spl-program-error",
- "spl-tlv-account-resolution",
  "spl-type-length-value",
  "thiserror 2.0.12",
 ]

--- a/p-token/Cargo.toml
+++ b/p-token/Cargo.toml
@@ -40,8 +40,8 @@ solana-signer = "2.2.1"
 solana-transaction = "2.2.3"
 solana-transaction-error = "2.2.1"
 solana-system-interface = { workspace = true }
-spl-token = { version="^8", features=["no-entrypoint"] }
-spl-token-2022 = { version="^9", features=["no-entrypoint"] }
+spl-token-interface = "1"
+spl-token-2022-interface = "1"
 
 [lints]
 workspace = true

--- a/p-token/tests/amount_to_ui_amount.rs
+++ b/p-token/tests/amount_to_ui_amount.rs
@@ -33,8 +33,12 @@ async fn amount_to_ui_amount() {
     .await
     .unwrap();
 
-    let amount_to_ui_amount_ix =
-        spl_token::instruction::amount_to_ui_amount(&spl_token::ID, &mint, 1000).unwrap();
+    let amount_to_ui_amount_ix = spl_token_interface::instruction::amount_to_ui_amount(
+        &spl_token_interface::ID,
+        &mint,
+        1000,
+    )
+    .unwrap();
 
     let tx = Transaction::new_signed_with_payer(
         &[amount_to_ui_amount_ix],
@@ -70,7 +74,8 @@ fn amount_to_ui_amount_with_maximum_decimals() {
     //  succeed and return the correct UI amount.
 
     let instruction =
-        spl_token::instruction::amount_to_ui_amount(&spl_token::ID, &mint, 20).unwrap();
+        spl_token_interface::instruction::amount_to_ui_amount(&spl_token_interface::ID, &mint, 20)
+            .unwrap();
 
     // The expected UI amount is "0.000....002" without the trailing zeros.
     let mut ui_amount = [b'0'; u8::MAX as usize + 1];
@@ -102,8 +107,12 @@ fn amount_to_ui_amount_with_u64_max() {
     // When we convert an u64::MAX amount using the mint, the transaction should
     // succeed and return the correct UI amount.
 
-    let instruction =
-        spl_token::instruction::amount_to_ui_amount(&spl_token::ID, &mint, u64::MAX).unwrap();
+    let instruction = spl_token_interface::instruction::amount_to_ui_amount(
+        &spl_token_interface::ID,
+        &mint,
+        u64::MAX,
+    )
+    .unwrap();
 
     // The expected UI amount is a `u64::MAX` with 255 decimal places.
     //   - 2 digits for `0.`

--- a/p-token/tests/approve.rs
+++ b/p-token/tests/approve.rs
@@ -52,8 +52,8 @@ async fn approve() {
 
     let delegate = Pubkey::new_unique();
 
-    let approve_ix = spl_token::instruction::approve(
-        &spl_token::ID,
+    let approve_ix = spl_token_interface::instruction::approve(
+        &spl_token_interface::ID,
         &account,
         &delegate,
         &owner.pubkey(),
@@ -77,7 +77,7 @@ async fn approve() {
     assert!(account.is_some());
 
     let account = account.unwrap();
-    let account = spl_token::state::Account::unpack(&account.data).unwrap();
+    let account = spl_token_interface::state::Account::unpack(&account.data).unwrap();
 
     assert!(account.delegate.is_some());
     assert!(account.delegate.unwrap() == delegate);

--- a/p-token/tests/approve_checked.rs
+++ b/p-token/tests/approve_checked.rs
@@ -52,7 +52,7 @@ async fn approve_checked() {
 
     let delegate = Pubkey::new_unique();
 
-    let approve_ix = spl_token::instruction::approve_checked(
+    let approve_ix = spl_token_interface::instruction::approve_checked(
         &TOKEN_PROGRAM_ID,
         &account,
         &mint,
@@ -79,7 +79,7 @@ async fn approve_checked() {
     assert!(account.is_some());
 
     let account = account.unwrap();
-    let account = spl_token::state::Account::unpack(&account.data).unwrap();
+    let account = spl_token_interface::state::Account::unpack(&account.data).unwrap();
 
     assert!(account.delegate.is_some());
     assert!(account.delegate.unwrap() == delegate);

--- a/p-token/tests/batch.rs
+++ b/p-token/tests/batch.rs
@@ -33,7 +33,7 @@ fn batch_instruction(instructions: Vec<Instruction>) -> Result<Instruction, Prog
 
     for instruction in instructions {
         // Error out on non-token IX.
-        if instruction.program_id.ne(&spl_token::ID) {
+        if instruction.program_id.ne(&spl_token_interface::ID) {
             return Err(ProgramError::IncorrectProgramId);
         }
 
@@ -45,7 +45,7 @@ fn batch_instruction(instructions: Vec<Instruction>) -> Result<Instruction, Prog
     }
 
     Ok(Instruction {
-        program_id: spl_token::ID,
+        program_id: spl_token_interface::ID,
         data,
         accounts,
     })
@@ -59,10 +59,10 @@ async fn batch_initialize_mint_transfer_close() {
 
     let rent = context.banks_client.get_rent().await.unwrap();
 
-    let mint_len = spl_token::state::Mint::LEN;
+    let mint_len = spl_token_interface::state::Mint::LEN;
     let mint_rent = rent.minimum_balance(mint_len);
 
-    let account_len = spl_token::state::Account::LEN;
+    let account_len = spl_token_interface::state::Account::LEN;
     let account_rent = rent.minimum_balance(account_len);
 
     // Create a mint
@@ -75,7 +75,7 @@ async fn batch_initialize_mint_transfer_close() {
         mint_len as u64,
         &TOKEN_PROGRAM_ID,
     );
-    let initialize_mint_ix = spl_token::instruction::initialize_mint(
+    let initialize_mint_ix = spl_token_interface::instruction::initialize_mint(
         &TOKEN_PROGRAM_ID,
         &mint_a.pubkey(),
         &mint_authority.pubkey(),
@@ -94,14 +94,15 @@ async fn batch_initialize_mint_transfer_close() {
         mint_len as u64,
         &TOKEN_PROGRAM_ID,
     );
-    let initialize_mint_with_freeze_authority_ix = spl_token::instruction::initialize_mint2(
-        &TOKEN_PROGRAM_ID,
-        &mint_b.pubkey(),
-        &mint_authority.pubkey(),
-        Some(&freeze_authority),
-        6,
-    )
-    .unwrap();
+    let initialize_mint_with_freeze_authority_ix =
+        spl_token_interface::instruction::initialize_mint2(
+            &TOKEN_PROGRAM_ID,
+            &mint_b.pubkey(),
+            &mint_authority.pubkey(),
+            Some(&freeze_authority),
+            6,
+        )
+        .unwrap();
 
     // Create 2 token accounts for mint A and 1 for mint B
     let owner_a = Keypair::new();
@@ -123,14 +124,14 @@ async fn batch_initialize_mint_transfer_close() {
         account_len as u64,
         &TOKEN_PROGRAM_ID,
     );
-    let intialize_owner_a_ta_a = spl_token::instruction::initialize_account3(
+    let intialize_owner_a_ta_a = spl_token_interface::instruction::initialize_account3(
         &TOKEN_PROGRAM_ID,
         &owner_a_ta_a.pubkey(),
         &mint_a.pubkey(),
         &owner_a.pubkey(),
     )
     .unwrap();
-    let intialize_owner_b_ta_a = spl_token::instruction::initialize_account3(
+    let intialize_owner_b_ta_a = spl_token_interface::instruction::initialize_account3(
         &TOKEN_PROGRAM_ID,
         &owner_b_ta_a.pubkey(),
         &mint_a.pubkey(),
@@ -139,7 +140,7 @@ async fn batch_initialize_mint_transfer_close() {
     .unwrap();
 
     // Mint Token A to Owner A
-    let mint_token_a_to_owner_a = spl_token::instruction::mint_to(
+    let mint_token_a_to_owner_a = spl_token_interface::instruction::mint_to(
         &TOKEN_PROGRAM_ID,
         &mint_a.pubkey(),
         &owner_a_ta_a.pubkey(),
@@ -150,7 +151,7 @@ async fn batch_initialize_mint_transfer_close() {
     .unwrap();
 
     // Transfer Token A from Owner A to Owner B
-    let transfer_token_a_to_owner_b = spl_token::instruction::transfer(
+    let transfer_token_a_to_owner_b = spl_token_interface::instruction::transfer(
         &TOKEN_PROGRAM_ID,
         &owner_a_ta_a.pubkey(),
         &owner_b_ta_a.pubkey(),
@@ -161,7 +162,7 @@ async fn batch_initialize_mint_transfer_close() {
     .unwrap();
 
     // Close Token A
-    let close_owner_a_ta_a = spl_token::instruction::close_account(
+    let close_owner_a_ta_a = spl_token_interface::instruction::close_account(
         &TOKEN_PROGRAM_ID,
         &owner_a_ta_a.pubkey(),
         &owner_a.pubkey(),
@@ -209,7 +210,8 @@ async fn batch_initialize_mint_transfer_close() {
         .await
         .unwrap();
     assert!(mint_a_account.is_some());
-    let mint_a_account = spl_token::state::Mint::unpack(&mint_a_account.unwrap().data).unwrap();
+    let mint_a_account =
+        spl_token_interface::state::Mint::unpack(&mint_a_account.unwrap().data).unwrap();
     assert_eq!(mint_a_account.supply, 1000000);
 
     let mint_b_account = context
@@ -218,7 +220,8 @@ async fn batch_initialize_mint_transfer_close() {
         .await
         .unwrap();
     assert!(mint_b_account.is_some());
-    let mint_b_account = spl_token::state::Mint::unpack(&mint_b_account.unwrap().data).unwrap();
+    let mint_b_account =
+        spl_token_interface::state::Mint::unpack(&mint_b_account.unwrap().data).unwrap();
     assert_eq!(mint_b_account.supply, 0);
 
     let owner_b_ta_a_account = context
@@ -228,7 +231,7 @@ async fn batch_initialize_mint_transfer_close() {
         .unwrap();
     assert!(owner_b_ta_a_account.is_some());
     let owner_b_ta_a_account =
-        spl_token::state::Account::unpack(&owner_b_ta_a_account.unwrap().data).unwrap();
+        spl_token_interface::state::Account::unpack(&owner_b_ta_a_account.unwrap().data).unwrap();
     assert_eq!(owner_b_ta_a_account.amount, 1000000);
 
     let closed_owner_a_ta_a = context
@@ -345,7 +348,7 @@ async fn batch_transfer() {
     let destination_account =
         create_token_account(&mint_key, &authority_key, false, 0, &TOKEN_PROGRAM_ID);
 
-    let instruction = batch_instruction(vec![spl_token::instruction::transfer(
+    let instruction = batch_instruction(vec![spl_token_interface::instruction::transfer(
         &TOKEN_PROGRAM_ID,
         &source_account_key,
         &destination_account_key,
@@ -403,7 +406,7 @@ async fn batch_fail_transfer_with_invalid_program_owner() {
     let destination_account =
         create_token_account(&native_mint, &authority_key, true, 0, &TOKEN_PROGRAM_ID);
 
-    let instruction = batch_instruction(vec![spl_token::instruction::transfer(
+    let instruction = batch_instruction(vec![spl_token_interface::instruction::transfer(
         &TOKEN_PROGRAM_ID,
         &source_account_key,
         &destination_account_key,
@@ -469,7 +472,7 @@ async fn batch_fail_transfer_checked_with_invalid_program_owner() {
     let destination_account =
         create_token_account(&native_mint_key, &authority_key, true, 0, &TOKEN_PROGRAM_ID);
 
-    let instruction = batch_instruction(vec![spl_token::instruction::transfer_checked(
+    let instruction = batch_instruction(vec![spl_token_interface::instruction::transfer_checked(
         &TOKEN_PROGRAM_ID,
         &source_account_key,
         &native_mint_key,
@@ -548,9 +551,9 @@ async fn batch_fail_swap_tokens_with_invalid_program_owner() {
     //   - transfer 300 from account A to account B
     //   - transfer 300 from account C to account A
     let instruction = batch_instruction(vec![
-        spl_token::instruction::sync_native(&TOKEN_PROGRAM_ID, &account_b_key).unwrap(),
-        spl_token::instruction::sync_native(&TOKEN_PROGRAM_ID, &account_c_key).unwrap(),
-        spl_token::instruction::transfer(
+        spl_token_interface::instruction::sync_native(&TOKEN_PROGRAM_ID, &account_b_key).unwrap(),
+        spl_token_interface::instruction::sync_native(&TOKEN_PROGRAM_ID, &account_c_key).unwrap(),
+        spl_token_interface::instruction::transfer(
             &TOKEN_PROGRAM_ID,
             &account_a_key,
             &account_b_key,
@@ -559,7 +562,7 @@ async fn batch_fail_swap_tokens_with_invalid_program_owner() {
             300,
         )
         .unwrap(),
-        spl_token::instruction::transfer(
+        spl_token_interface::instruction::transfer(
             &TOKEN_PROGRAM_ID,
             &account_c_key,
             &account_a_key,
@@ -621,7 +624,7 @@ async fn batch_fail_mint_to_with_invalid_program_owner() {
     let account_b = create_token_account(&mint_key, &authority_key, false, 0, &TOKEN_PROGRAM_ID);
 
     let instruction = batch_instruction(vec![
-        spl_token::instruction::mint_to(
+        spl_token_interface::instruction::mint_to(
             &TOKEN_PROGRAM_ID,
             &mint_key,
             &account_a_key,
@@ -630,7 +633,7 @@ async fn batch_fail_mint_to_with_invalid_program_owner() {
             1_000_000_000,
         )
         .unwrap(),
-        spl_token::instruction::mint_to(
+        spl_token_interface::instruction::mint_to(
             &TOKEN_PROGRAM_ID,
             &mint_key,
             &account_b_key,
@@ -698,7 +701,7 @@ async fn batch_fail_burn_with_invalid_program_owner() {
     );
 
     let instruction = batch_instruction(vec![
-        spl_token::instruction::mint_to(
+        spl_token_interface::instruction::mint_to(
             &TOKEN_PROGRAM_ID,
             &mint_key,
             &account_a_key,
@@ -707,7 +710,7 @@ async fn batch_fail_burn_with_invalid_program_owner() {
             1_000_000_000,
         )
         .unwrap(),
-        spl_token::instruction::mint_to(
+        spl_token_interface::instruction::mint_to(
             &TOKEN_PROGRAM_ID,
             &mint_key,
             &account_b_key,
@@ -716,7 +719,7 @@ async fn batch_fail_burn_with_invalid_program_owner() {
             1_000_000_000,
         )
         .unwrap(),
-        spl_token::instruction::burn(
+        spl_token_interface::instruction::burn(
             &TOKEN_PROGRAM_ID,
             &account_a_key,
             &mint_key,
@@ -725,7 +728,7 @@ async fn batch_fail_burn_with_invalid_program_owner() {
             1_000_000_000,
         )
         .unwrap(),
-        spl_token::instruction::burn(
+        spl_token_interface::instruction::burn(
             &TOKEN_PROGRAM_ID,
             &account_b_key,
             &mint_key,

--- a/p-token/tests/burn.rs
+++ b/p-token/tests/burn.rs
@@ -50,9 +50,15 @@ async fn burn() {
 
     // When we burn 50 tokens.
 
-    let burn_ix =
-        spl_token::instruction::burn(&spl_token::ID, &account, &mint, &owner.pubkey(), &[], 50)
-            .unwrap();
+    let burn_ix = spl_token_interface::instruction::burn(
+        &spl_token_interface::ID,
+        &account,
+        &mint,
+        &owner.pubkey(),
+        &[],
+        50,
+    )
+    .unwrap();
 
     let tx = Transaction::new_signed_with_payer(
         &[burn_ix],
@@ -69,7 +75,7 @@ async fn burn() {
     assert!(account.is_some());
 
     let account = account.unwrap();
-    let account = spl_token::state::Account::unpack(&account.data).unwrap();
+    let account = spl_token_interface::state::Account::unpack(&account.data).unwrap();
 
     assert!(account.amount == 50);
 }

--- a/p-token/tests/burn_checked.rs
+++ b/p-token/tests/burn_checked.rs
@@ -50,8 +50,8 @@ async fn burn_checked() {
 
     // When we burn 50 tokens.
 
-    let burn_ix = spl_token::instruction::burn_checked(
-        &spl_token::ID,
+    let burn_ix = spl_token_interface::instruction::burn_checked(
+        &spl_token_interface::ID,
         &account,
         &mint,
         &owner.pubkey(),
@@ -76,7 +76,7 @@ async fn burn_checked() {
     assert!(account.is_some());
 
     let account = account.unwrap();
-    let account = spl_token::state::Account::unpack(&account.data).unwrap();
+    let account = spl_token_interface::state::Account::unpack(&account.data).unwrap();
 
     assert!(account.amount == 50);
 }

--- a/p-token/tests/close_account.rs
+++ b/p-token/tests/close_account.rs
@@ -41,8 +41,8 @@ async fn close_account() {
 
     // When we close the account.
 
-    let close_account_ix = spl_token::instruction::close_account(
-        &spl_token::ID,
+    let close_account_ix = spl_token_interface::instruction::close_account(
+        &spl_token_interface::ID,
         &account,
         &owner.pubkey(),
         &owner.pubkey(),

--- a/p-token/tests/freeze_account.rs
+++ b/p-token/tests/freeze_account.rs
@@ -7,7 +7,7 @@ use {
     solana_program_test::{tokio, ProgramTest},
     solana_signer::Signer,
     solana_transaction::Transaction,
-    spl_token::state::AccountState,
+    spl_token_interface::state::AccountState,
 };
 
 #[tokio::test]
@@ -42,8 +42,8 @@ async fn freeze_account() {
 
     // When we freeze the account.
 
-    let freeze_account_ix = spl_token::instruction::freeze_account(
-        &spl_token::ID,
+    let freeze_account_ix = spl_token_interface::instruction::freeze_account(
+        &spl_token_interface::ID,
         &account,
         &mint,
         &freeze_authority.pubkey(),
@@ -65,7 +65,7 @@ async fn freeze_account() {
     assert!(token_account.is_some());
 
     let token_account = token_account.unwrap();
-    let token_account = spl_token::state::Account::unpack(&token_account.data).unwrap();
+    let token_account = spl_token_interface::state::Account::unpack(&token_account.data).unwrap();
 
     assert_eq!(token_account.state, AccountState::Frozen);
 }

--- a/p-token/tests/initialize_account.rs
+++ b/p-token/tests/initialize_account.rs
@@ -39,8 +39,8 @@ async fn initialize_account() {
     let account_size = 165;
     let rent = context.banks_client.get_rent().await.unwrap();
 
-    let initialize_ix = spl_token::instruction::initialize_account(
-        &spl_token::ID,
+    let initialize_ix = spl_token_interface::instruction::initialize_account(
+        &spl_token_interface::ID,
         &account.pubkey(),
         &mint,
         &owner,
@@ -79,7 +79,7 @@ async fn initialize_account() {
     assert!(account.is_some());
 
     let account = account.unwrap();
-    let account = spl_token::state::Account::unpack(&account.data).unwrap();
+    let account = spl_token_interface::state::Account::unpack(&account.data).unwrap();
 
     assert!(!account.is_frozen());
     assert!(account.owner == owner);

--- a/p-token/tests/initialize_account2.rs
+++ b/p-token/tests/initialize_account2.rs
@@ -39,8 +39,8 @@ async fn initialize_account2() {
     let account_size = 165;
     let rent = context.banks_client.get_rent().await.unwrap();
 
-    let initialize_ix = spl_token::instruction::initialize_account2(
-        &spl_token::ID,
+    let initialize_ix = spl_token_interface::instruction::initialize_account2(
+        &spl_token_interface::ID,
         &account.pubkey(),
         &mint,
         &owner,
@@ -79,7 +79,7 @@ async fn initialize_account2() {
     assert!(account.is_some());
 
     let account = account.unwrap();
-    let account = spl_token::state::Account::unpack(&account.data).unwrap();
+    let account = spl_token_interface::state::Account::unpack(&account.data).unwrap();
 
     assert!(!account.is_frozen());
     assert!(account.owner == owner);

--- a/p-token/tests/initialize_account3.rs
+++ b/p-token/tests/initialize_account3.rs
@@ -39,8 +39,8 @@ async fn initialize_account3() {
     let account_size = 165;
     let rent = context.banks_client.get_rent().await.unwrap();
 
-    let initialize_ix = spl_token::instruction::initialize_account3(
-        &spl_token::ID,
+    let initialize_ix = spl_token_interface::instruction::initialize_account3(
+        &spl_token_interface::ID,
         &account.pubkey(),
         &mint,
         &owner,
@@ -79,7 +79,7 @@ async fn initialize_account3() {
     assert!(account.is_some());
 
     let account = account.unwrap();
-    let account = spl_token::state::Account::unpack(&account.data).unwrap();
+    let account = spl_token_interface::state::Account::unpack(&account.data).unwrap();
 
     assert!(!account.is_frozen());
     assert!(account.owner == owner);

--- a/p-token/tests/initialize_immutable_owner.rs
+++ b/p-token/tests/initialize_immutable_owner.rs
@@ -8,7 +8,7 @@ use {
     solana_signer::Signer,
     solana_system_interface::instruction::create_account,
     solana_transaction::Transaction,
-    spl_token::state::AccountState,
+    spl_token_interface::state::AccountState,
 };
 
 #[tokio::test]
@@ -34,8 +34,11 @@ async fn initialize_immutable_owner() {
             account_size as u64,
             &TOKEN_PROGRAM_ID,
         ),
-        spl_token::instruction::initialize_immutable_owner(&TOKEN_PROGRAM_ID, &account.pubkey())
-            .unwrap(),
+        spl_token_interface::instruction::initialize_immutable_owner(
+            &TOKEN_PROGRAM_ID,
+            &account.pubkey(),
+        )
+        .unwrap(),
     ];
 
     let tx = Transaction::new_signed_with_payer(
@@ -57,7 +60,7 @@ async fn initialize_immutable_owner() {
     assert!(account.is_some());
 
     let account = account.unwrap();
-    let account = spl_token::state::Account::unpack_unchecked(&account.data).unwrap();
+    let account = spl_token_interface::state::Account::unpack_unchecked(&account.data).unwrap();
 
     assert_eq!(account.state, AccountState::Uninitialized);
 }

--- a/p-token/tests/initialize_mint.rs
+++ b/p-token/tests/initialize_mint.rs
@@ -29,8 +29,8 @@ async fn initialize_mint() {
     let account_size = size_of::<Mint>();
     let rent = context.banks_client.get_rent().await.unwrap();
 
-    let initialize_ix = spl_token::instruction::initialize_mint(
-        &spl_token::ID,
+    let initialize_ix = spl_token_interface::instruction::initialize_mint(
+        &spl_token_interface::ID,
         &account.pubkey(),
         &mint_authority,
         Some(&freeze_authority),
@@ -70,7 +70,7 @@ async fn initialize_mint() {
     assert!(account.is_some());
 
     let account = account.unwrap();
-    let mint = spl_token::state::Mint::unpack(&account.data).unwrap();
+    let mint = spl_token_interface::state::Mint::unpack(&account.data).unwrap();
 
     assert!(mint.is_initialized);
     assert!(mint.mint_authority == COption::Some(mint_authority));

--- a/p-token/tests/initialize_mint2.rs
+++ b/p-token/tests/initialize_mint2.rs
@@ -29,8 +29,8 @@ async fn initialize_mint2() {
     let account_size = size_of::<Mint>();
     let rent = context.banks_client.get_rent().await.unwrap();
 
-    let initialize_ix = spl_token::instruction::initialize_mint2(
-        &spl_token::ID,
+    let initialize_ix = spl_token_interface::instruction::initialize_mint2(
+        &spl_token_interface::ID,
         &account.pubkey(),
         &mint_authority,
         Some(&freeze_authority),
@@ -70,7 +70,7 @@ async fn initialize_mint2() {
     assert!(account.is_some());
 
     let account = account.unwrap();
-    let mint = spl_token::state::Mint::unpack(&account.data).unwrap();
+    let mint = spl_token_interface::state::Mint::unpack(&account.data).unwrap();
 
     assert!(mint.is_initialized);
     assert!(mint.mint_authority == COption::Some(mint_authority));

--- a/p-token/tests/initialize_multisig.rs
+++ b/p-token/tests/initialize_multisig.rs
@@ -9,7 +9,7 @@ use {
     solana_signer::Signer,
     solana_system_interface::instruction::create_account,
     solana_transaction::Transaction,
-    spl_token::state::Multisig,
+    spl_token_interface::state::Multisig,
 };
 
 #[tokio::test]
@@ -28,8 +28,8 @@ async fn initialize_multisig() {
 
     let rent = context.banks_client.get_rent().await.unwrap();
 
-    let initialize_ix = spl_token::instruction::initialize_multisig(
-        &spl_token::ID,
+    let initialize_ix = spl_token_interface::instruction::initialize_multisig(
+        &spl_token_interface::ID,
         &multisig.pubkey(),
         &signers,
         2,
@@ -68,7 +68,7 @@ async fn initialize_multisig() {
     assert!(account.is_some());
 
     let account = account.unwrap();
-    let multisig = spl_token::state::Multisig::unpack(&account.data).unwrap();
+    let multisig = spl_token_interface::state::Multisig::unpack(&account.data).unwrap();
 
     assert!(multisig.is_initialized);
     assert_eq!(multisig.n, 3);

--- a/p-token/tests/initialize_multisig2.rs
+++ b/p-token/tests/initialize_multisig2.rs
@@ -9,7 +9,7 @@ use {
     solana_signer::Signer,
     solana_system_interface::instruction::create_account,
     solana_transaction::Transaction,
-    spl_token::state::Multisig,
+    spl_token_interface::state::Multisig,
 };
 
 #[tokio::test]
@@ -28,8 +28,8 @@ async fn initialize_multisig2() {
 
     let rent = context.banks_client.get_rent().await.unwrap();
 
-    let initialize_ix = spl_token::instruction::initialize_multisig2(
-        &spl_token::ID,
+    let initialize_ix = spl_token_interface::instruction::initialize_multisig2(
+        &spl_token_interface::ID,
         &multisig.pubkey(),
         &signers,
         2,
@@ -68,7 +68,7 @@ async fn initialize_multisig2() {
     assert!(account.is_some());
 
     let account = account.unwrap();
-    let multisig = spl_token::state::Multisig::unpack(&account.data).unwrap();
+    let multisig = spl_token_interface::state::Multisig::unpack(&account.data).unwrap();
 
     assert!(multisig.is_initialized);
     assert_eq!(multisig.n, 3);

--- a/p-token/tests/mint_to.rs
+++ b/p-token/tests/mint_to.rs
@@ -39,8 +39,8 @@ async fn mint_to() {
 
     // When we mint tokens to it.
 
-    let mint_ix = spl_token::instruction::mint_to(
-        &spl_token::ID,
+    let mint_ix = spl_token_interface::instruction::mint_to(
+        &spl_token_interface::ID,
         &mint,
         &account,
         &mint_authority.pubkey(),
@@ -64,7 +64,7 @@ async fn mint_to() {
     assert!(account.is_some());
 
     let account = account.unwrap();
-    let account = spl_token::state::Account::unpack(&account.data).unwrap();
+    let account = spl_token_interface::state::Account::unpack(&account.data).unwrap();
 
     assert!(account.amount == 100);
 }

--- a/p-token/tests/mint_to_checked.rs
+++ b/p-token/tests/mint_to_checked.rs
@@ -39,8 +39,8 @@ async fn mint_to_checked() {
 
     // When we mint tokens to it.
 
-    let mint_ix = spl_token::instruction::mint_to_checked(
-        &spl_token::ID,
+    let mint_ix = spl_token_interface::instruction::mint_to_checked(
+        &spl_token_interface::ID,
         &mint,
         &account,
         &mint_authority.pubkey(),
@@ -65,7 +65,7 @@ async fn mint_to_checked() {
     assert!(account.is_some());
 
     let account = account.unwrap();
-    let account = spl_token::state::Account::unpack(&account.data).unwrap();
+    let account = spl_token_interface::state::Account::unpack(&account.data).unwrap();
 
     assert!(account.amount == 100);
 }

--- a/p-token/tests/revoke.rs
+++ b/p-token/tests/revoke.rs
@@ -64,8 +64,13 @@ async fn revoke() {
 
     // When we revoke the delegation.
 
-    let revoke_ix =
-        spl_token::instruction::revoke(&spl_token::ID, &account, &owner.pubkey(), &[]).unwrap();
+    let revoke_ix = spl_token_interface::instruction::revoke(
+        &spl_token_interface::ID,
+        &account,
+        &owner.pubkey(),
+        &[],
+    )
+    .unwrap();
 
     let tx = Transaction::new_signed_with_payer(
         &[revoke_ix],
@@ -82,7 +87,7 @@ async fn revoke() {
     assert!(account.is_some());
 
     let account = account.unwrap();
-    let account = spl_token::state::Account::unpack(&account.data).unwrap();
+    let account = spl_token_interface::state::Account::unpack(&account.data).unwrap();
 
     assert!(account.delegate.is_none());
     assert!(account.delegated_amount == 0);

--- a/p-token/tests/set_authority.rs
+++ b/p-token/tests/set_authority.rs
@@ -9,7 +9,7 @@ use {
     solana_pubkey::Pubkey,
     solana_signer::Signer,
     solana_transaction::Transaction,
-    spl_token::instruction::AuthorityType,
+    spl_token_interface::instruction::AuthorityType,
 };
 
 #[tokio::test]
@@ -36,8 +36,8 @@ async fn set_authority() {
 
     let new_authority = Pubkey::new_unique();
 
-    let set_authority_ix = spl_token::instruction::set_authority(
-        &spl_token::ID,
+    let set_authority_ix = spl_token_interface::instruction::set_authority(
+        &spl_token_interface::ID,
         &mint,
         Some(&new_authority),
         AuthorityType::FreezeAccount,
@@ -61,7 +61,7 @@ async fn set_authority() {
     assert!(account.is_some());
 
     let account = account.unwrap();
-    let mint = spl_token::state::Mint::unpack(&account.data).unwrap();
+    let mint = spl_token_interface::state::Mint::unpack(&account.data).unwrap();
 
     assert!(mint.freeze_authority == COption::Some(new_authority));
 }

--- a/p-token/tests/setup/account.rs
+++ b/p-token/tests/setup/account.rs
@@ -15,9 +15,13 @@ pub async fn initialize(
     let account_size = 165;
     let rent = context.banks_client.get_rent().await.unwrap();
 
-    let mut initialize_ix =
-        spl_token::instruction::initialize_account(&spl_token::ID, &account.pubkey(), mint, owner)
-            .unwrap();
+    let mut initialize_ix = spl_token_interface::instruction::initialize_account(
+        &spl_token_interface::ID,
+        &account.pubkey(),
+        mint,
+        owner,
+    )
+    .unwrap();
     initialize_ix.program_id = *program_id;
 
     let instructions = vec![
@@ -50,8 +54,8 @@ pub async fn approve(
     amount: u64,
     program_id: &Pubkey,
 ) {
-    let mut approve_ix = spl_token::instruction::approve(
-        &spl_token::ID,
+    let mut approve_ix = spl_token_interface::instruction::approve(
+        &spl_token_interface::ID,
         account,
         delegate,
         &owner.pubkey(),
@@ -77,8 +81,8 @@ pub async fn freeze(
     freeze_authority: &Keypair,
     program_id: &Pubkey,
 ) {
-    let mut freeze_account_ix = spl_token::instruction::freeze_account(
-        &spl_token::ID,
+    let mut freeze_account_ix = spl_token_interface::instruction::freeze_account(
+        &spl_token_interface::ID,
         account,
         mint,
         &freeze_authority.pubkey(),

--- a/p-token/tests/setup/mint.rs
+++ b/p-token/tests/setup/mint.rs
@@ -32,8 +32,8 @@ pub async fn initialize_with_decimals(
     let account_size = size_of::<Mint>();
     let rent = context.banks_client.get_rent().await.unwrap();
 
-    let mut initialize_ix = spl_token::instruction::initialize_mint(
-        &spl_token::ID,
+    let mut initialize_ix = spl_token_interface::instruction::initialize_mint(
+        &spl_token_interface::ID,
         &account.pubkey(),
         &mint_authority,
         freeze_authority.as_ref(),
@@ -75,8 +75,8 @@ pub async fn mint(
     amount: u64,
     program_id: &Pubkey,
 ) -> Result<(), BanksClientError> {
-    let mut mint_ix = spl_token::instruction::mint_to(
-        &spl_token::ID,
+    let mut mint_ix = spl_token_interface::instruction::mint_to(
+        &spl_token_interface::ID,
         mint,
         account,
         &mint_authority.pubkey(),

--- a/p-token/tests/sync_native.rs
+++ b/p-token/tests/sync_native.rs
@@ -75,7 +75,8 @@ async fn sync_native() {
     source_account.lamports += 2_000_000_000;
 
     let instruction =
-        spl_token::instruction::sync_native(&TOKEN_PROGRAM_ID, &source_account_key).unwrap();
+        spl_token_interface::instruction::sync_native(&TOKEN_PROGRAM_ID, &source_account_key)
+            .unwrap();
 
     // Executes the sync_native instruction.
 
@@ -86,7 +87,7 @@ async fn sync_native() {
 
     result.resulting_accounts.iter().for_each(|(key, account)| {
         if *key == source_account_key {
-            let token_account = spl_token::state::Account::unpack(&account.data).unwrap();
+            let token_account = spl_token_interface::state::Account::unpack(&account.data).unwrap();
             assert_eq!(token_account.amount, 2_000_000_000);
         }
     });

--- a/p-token/tests/thaw_account.rs
+++ b/p-token/tests/thaw_account.rs
@@ -7,7 +7,7 @@ use {
     solana_program_test::{tokio, ProgramTest},
     solana_signer::Signer,
     solana_transaction::Transaction,
-    spl_token::state::AccountState,
+    spl_token_interface::state::AccountState,
 };
 
 #[tokio::test]
@@ -51,8 +51,8 @@ async fn thaw_account() {
 
     // When we thaw the account.
 
-    let thaw_account_ix = spl_token::instruction::thaw_account(
-        &spl_token::ID,
+    let thaw_account_ix = spl_token_interface::instruction::thaw_account(
+        &spl_token_interface::ID,
         &account,
         &mint,
         &freeze_authority.pubkey(),
@@ -74,7 +74,7 @@ async fn thaw_account() {
     assert!(token_account.is_some());
 
     let token_account = token_account.unwrap();
-    let token_account = spl_token::state::Account::unpack(&token_account.data).unwrap();
+    let token_account = spl_token_interface::state::Account::unpack(&token_account.data).unwrap();
 
     assert_eq!(token_account.state, AccountState::Initialized);
 }

--- a/p-token/tests/transfer.rs
+++ b/p-token/tests/transfer.rs
@@ -55,8 +55,8 @@ async fn transfer() {
     let destination_account =
         account::initialize(&mut context, &mint, &destination, &TOKEN_PROGRAM_ID).await;
 
-    let transfer_ix = spl_token::instruction::transfer(
-        &spl_token::ID,
+    let transfer_ix = spl_token_interface::instruction::transfer(
+        &spl_token_interface::ID,
         &account,
         &destination_account,
         &owner.pubkey(),
@@ -80,7 +80,7 @@ async fn transfer() {
     assert!(account.is_some());
 
     let account = account.unwrap();
-    let account = spl_token::state::Account::unpack(&account.data).unwrap();
+    let account = spl_token_interface::state::Account::unpack(&account.data).unwrap();
 
     assert!(account.amount == 0);
 }

--- a/p-token/tests/transfer_checked.rs
+++ b/p-token/tests/transfer_checked.rs
@@ -55,8 +55,8 @@ async fn transfer_checked() {
     let destination_account =
         account::initialize(&mut context, &mint, &destination, &TOKEN_PROGRAM_ID).await;
 
-    let transfer_ix = spl_token::instruction::transfer_checked(
-        &spl_token::ID,
+    let transfer_ix = spl_token_interface::instruction::transfer_checked(
+        &spl_token_interface::ID,
         &account,
         &mint,
         &destination_account,
@@ -82,7 +82,7 @@ async fn transfer_checked() {
     assert!(account.is_some());
 
     let account = account.unwrap();
-    let account = spl_token::state::Account::unpack(&account.data).unwrap();
+    let account = spl_token_interface::state::Account::unpack(&account.data).unwrap();
 
     assert!(account.amount == 0);
 }

--- a/p-token/tests/ui_amount_to_amount.rs
+++ b/p-token/tests/ui_amount_to_amount.rs
@@ -32,8 +32,12 @@ async fn ui_amount_to_amount() {
     .await
     .unwrap();
 
-    let ui_amount_to_amount_ix =
-        spl_token::instruction::ui_amount_to_amount(&spl_token::ID, &mint, "1000.00").unwrap();
+    let ui_amount_to_amount_ix = spl_token_interface::instruction::ui_amount_to_amount(
+        &spl_token_interface::ID,
+        &mint,
+        "1000.00",
+    )
+    .unwrap();
 
     let tx = Transaction::new_signed_with_payer(
         &[ui_amount_to_amount_ix],
@@ -75,8 +79,12 @@ fn ui_amount_to_amount_with_maximum_decimals() {
     // When we convert the ui amount using the mint, the transaction should
     // succeed and return 20 as the amount.
 
-    let instruction =
-        spl_token::instruction::ui_amount_to_amount(&spl_token::ID, &mint, input).unwrap();
+    let instruction = spl_token_interface::instruction::ui_amount_to_amount(
+        &spl_token_interface::ID,
+        &mint,
+        input,
+    )
+    .unwrap();
 
     mollusk().process_and_validate_instruction(
         &instruction,
@@ -107,8 +115,12 @@ fn fail_ui_amount_to_amount_with_invalid_ui_amount() {
     // When we try to convert the ui amount using the mint, the transaction should
     // fail with an error since the resulting value does not fit in an `u64`.
 
-    let instruction =
-        spl_token::instruction::ui_amount_to_amount(&spl_token::ID, &mint, input).unwrap();
+    let instruction = spl_token_interface::instruction::ui_amount_to_amount(
+        &spl_token_interface::ID,
+        &mint,
+        input,
+    )
+    .unwrap();
 
     mollusk().process_and_validate_instruction(
         &instruction,

--- a/p-token/tests/unwrap_lamports.rs
+++ b/p-token/tests/unwrap_lamports.rs
@@ -86,7 +86,7 @@ fn unwrap_lamports_instruction(
     }
 
     Ok(Instruction {
-        program_id: spl_token::ID,
+        program_id: spl_token_interface::ID,
         data,
         accounts,
     })
@@ -143,7 +143,7 @@ fn unwrap_lamports() {
     assert!(account.is_some());
 
     let account = account.unwrap();
-    let token_account = spl_token::state::Account::unpack(&account.data).unwrap();
+    let token_account = spl_token_interface::state::Account::unpack(&account.data).unwrap();
     assert_eq!(token_account.amount, 0);
 }
 
@@ -198,7 +198,7 @@ fn unwrap_lamports_with_amount() {
     assert!(account.is_some());
 
     let account = account.unwrap();
-    let token_account = spl_token::state::Account::unpack(&account.data).unwrap();
+    let token_account = spl_token_interface::state::Account::unpack(&account.data).unwrap();
     assert_eq!(token_account.amount, 0);
 }
 
@@ -296,7 +296,7 @@ fn unwrap_lamports_with_parial_amount() {
     assert!(account.is_some());
 
     let account = account.unwrap();
-    let token_account = spl_token::state::Account::unpack(&account.data).unwrap();
+    let token_account = spl_token_interface::state::Account::unpack(&account.data).unwrap();
     assert_eq!(token_account.amount, 1_000_000_000);
 }
 
@@ -431,7 +431,7 @@ fn unwrap_lamports_with_self_transfer() {
     assert!(account.is_some());
 
     let account = account.unwrap();
-    let token_account = spl_token::state::Account::unpack(&account.data).unwrap();
+    let token_account = spl_token_interface::state::Account::unpack(&account.data).unwrap();
     assert_eq!(token_account.amount, 2_000_000_000);
 }
 
@@ -536,7 +536,7 @@ fn unwrap_lamports_to_native_account() {
     assert!(account.is_some());
 
     let account = account.unwrap();
-    let token_account = spl_token::state::Account::unpack(&account.data).unwrap();
+    let token_account = spl_token_interface::state::Account::unpack(&account.data).unwrap();
     assert_eq!(token_account.amount, 0);
 
     // And the amount on the destination account must be 0 since we transferred
@@ -546,7 +546,7 @@ fn unwrap_lamports_to_native_account() {
     assert!(account.is_some());
 
     let account = account.unwrap();
-    let token_account = spl_token::state::Account::unpack(&account.data).unwrap();
+    let token_account = spl_token_interface::state::Account::unpack(&account.data).unwrap();
     assert_eq!(token_account.amount, 0);
 }
 
@@ -614,7 +614,7 @@ fn unwrap_lamports_to_token_account() {
     assert!(account.is_some());
 
     let account = account.unwrap();
-    let token_account = spl_token::state::Account::unpack(&account.data).unwrap();
+    let token_account = spl_token_interface::state::Account::unpack(&account.data).unwrap();
     assert_eq!(token_account.amount, 0);
 
     // And the amount on the destination account must be 0 since we transferred
@@ -624,6 +624,6 @@ fn unwrap_lamports_to_token_account() {
     assert!(account.is_some());
 
     let account = account.unwrap();
-    let token_account = spl_token::state::Account::unpack(&account.data).unwrap();
+    let token_account = spl_token_interface::state::Account::unpack(&account.data).unwrap();
     assert_eq!(token_account.amount, 0);
 }

--- a/p-token/tests/withdraw_excess_lamports.rs
+++ b/p-token/tests/withdraw_excess_lamports.rs
@@ -36,8 +36,8 @@ async fn withdraw_excess_lamports_from_mint() {
     let account_size = size_of::<Mint>();
     let rent = context.banks_client.get_rent().await.unwrap();
 
-    let initialize_ix = spl_token::instruction::initialize_mint(
-        &spl_token::ID,
+    let initialize_ix = spl_token_interface::instruction::initialize_mint(
+        &spl_token_interface::ID,
         &account.pubkey(),
         &mint_authority.pubkey(),
         Some(&freeze_authority),
@@ -84,8 +84,8 @@ async fn withdraw_excess_lamports_from_mint() {
 
     let destination = Pubkey::new_unique();
 
-    let mut withdraw_ix = spl_token_2022::instruction::withdraw_excess_lamports(
-        &spl_token_2022::ID,
+    let mut withdraw_ix = spl_token_2022_interface::instruction::withdraw_excess_lamports(
+        &spl_token_2022_interface::ID,
         &account_pubkey,
         &destination,
         &mint_authority.pubkey(),
@@ -144,8 +144,8 @@ async fn withdraw_excess_lamports_from_account() {
     let account_size = size_of::<Account>();
     let rent = context.banks_client.get_rent().await.unwrap();
 
-    let initialize_ix = spl_token::instruction::initialize_account(
-        &spl_token::ID,
+    let initialize_ix = spl_token_interface::instruction::initialize_account(
+        &spl_token_interface::ID,
         &account.pubkey(),
         &mint,
         &owner.pubkey(),
@@ -191,8 +191,8 @@ async fn withdraw_excess_lamports_from_account() {
 
     let destination = Pubkey::new_unique();
 
-    let mut withdraw_ix = spl_token_2022::instruction::withdraw_excess_lamports(
-        &spl_token_2022::ID,
+    let mut withdraw_ix = spl_token_2022_interface::instruction::withdraw_excess_lamports(
+        &spl_token_2022_interface::ID,
         &account_pubkey,
         &destination,
         &owner.pubkey(),
@@ -242,8 +242,8 @@ async fn withdraw_excess_lamports_from_multisig() {
     let rent = context.banks_client.get_rent().await.unwrap();
     let account_size = size_of::<Multisig>();
 
-    let initialize_ix = spl_token::instruction::initialize_multisig(
-        &spl_token::ID,
+    let initialize_ix = spl_token_interface::instruction::initialize_multisig(
+        &spl_token_interface::ID,
         &multisig.pubkey(),
         &signers,
         3,
@@ -289,8 +289,8 @@ async fn withdraw_excess_lamports_from_multisig() {
 
     let destination = Pubkey::new_unique();
 
-    let mut withdraw_ix = spl_token_2022::instruction::withdraw_excess_lamports(
-        &spl_token_2022::ID,
+    let mut withdraw_ix = spl_token_2022_interface::instruction::withdraw_excess_lamports(
+        &spl_token_2022_interface::ID,
         &multisig.pubkey(),
         &destination,
         &multisig.pubkey(),
@@ -336,8 +336,8 @@ async fn fail_withdraw_excess_lamports_from_mint_wrong_authority() {
     let account_size = size_of::<Mint>();
     let rent = context.banks_client.get_rent().await.unwrap();
 
-    let initialize_ix = spl_token::instruction::initialize_mint(
-        &spl_token::ID,
+    let initialize_ix = spl_token_interface::instruction::initialize_mint(
+        &spl_token_interface::ID,
         &account.pubkey(),
         &mint_authority.pubkey(),
         Some(&freeze_authority),
@@ -385,8 +385,8 @@ async fn fail_withdraw_excess_lamports_from_mint_wrong_authority() {
     let destination = Pubkey::new_unique();
     let wrong_authority = Keypair::new();
 
-    let mut withdraw_ix = spl_token_2022::instruction::withdraw_excess_lamports(
-        &spl_token_2022::ID,
+    let mut withdraw_ix = spl_token_2022_interface::instruction::withdraw_excess_lamports(
+        &spl_token_2022_interface::ID,
         &account_pubkey,
         &destination,
         &wrong_authority.pubkey(),
@@ -450,8 +450,8 @@ async fn fail_withdraw_excess_lamports_from_account_wrong_authority() {
     let account_size = size_of::<Account>();
     let rent = context.banks_client.get_rent().await.unwrap();
 
-    let initialize_ix = spl_token::instruction::initialize_account(
-        &spl_token::ID,
+    let initialize_ix = spl_token_interface::instruction::initialize_account(
+        &spl_token_interface::ID,
         &account.pubkey(),
         &mint,
         &owner.pubkey(),
@@ -498,8 +498,8 @@ async fn fail_withdraw_excess_lamports_from_account_wrong_authority() {
     let destination = Pubkey::new_unique();
     let wrong_owner = Keypair::new();
 
-    let mut withdraw_ix = spl_token_2022::instruction::withdraw_excess_lamports(
-        &spl_token_2022::ID,
+    let mut withdraw_ix = spl_token_2022_interface::instruction::withdraw_excess_lamports(
+        &spl_token_2022_interface::ID,
         &account_pubkey,
         &destination,
         &wrong_owner.pubkey(),
@@ -554,8 +554,8 @@ async fn fail_withdraw_excess_lamports_from_multisig_wrong_authority() {
     let rent = context.banks_client.get_rent().await.unwrap();
     let account_size = size_of::<Multisig>();
 
-    let initialize_ix = spl_token::instruction::initialize_multisig(
-        &spl_token::ID,
+    let initialize_ix = spl_token_interface::instruction::initialize_multisig(
+        &spl_token_interface::ID,
         &multisig.pubkey(),
         &signers,
         3,
@@ -602,8 +602,8 @@ async fn fail_withdraw_excess_lamports_from_multisig_wrong_authority() {
     let destination = Pubkey::new_unique();
     let wrong_authority = Keypair::new();
 
-    let mut withdraw_ix = spl_token_2022::instruction::withdraw_excess_lamports(
-        &spl_token_2022::ID,
+    let mut withdraw_ix = spl_token_2022_interface::instruction::withdraw_excess_lamports(
+        &spl_token_2022_interface::ID,
         &multisig.pubkey(),
         &destination,
         &wrong_authority.pubkey(),
@@ -658,8 +658,8 @@ async fn fail_withdraw_excess_lamports_from_multisig_missing_signer() {
     let rent = context.banks_client.get_rent().await.unwrap();
     let account_size = size_of::<Multisig>();
 
-    let initialize_ix = spl_token::instruction::initialize_multisig(
-        &spl_token::ID,
+    let initialize_ix = spl_token_interface::instruction::initialize_multisig(
+        &spl_token_interface::ID,
         &multisig.pubkey(),
         &signers,
         3,
@@ -705,8 +705,8 @@ async fn fail_withdraw_excess_lamports_from_multisig_missing_signer() {
 
     let destination = Pubkey::new_unique();
 
-    let mut withdraw_ix = spl_token_2022::instruction::withdraw_excess_lamports(
-        &spl_token_2022::ID,
+    let mut withdraw_ix = spl_token_2022_interface::instruction::withdraw_excess_lamports(
+        &spl_token_2022_interface::ID,
         &multisig.pubkey(),
         &destination,
         &multisig.pubkey(),
@@ -757,8 +757,8 @@ async fn withdraw_excess_lamports_from_mint_with_no_authority() {
     let account_size = size_of::<Mint>();
     let rent = context.banks_client.get_rent().await.unwrap();
 
-    let initialize_ix = spl_token::instruction::initialize_mint(
-        &spl_token::ID,
+    let initialize_ix = spl_token_interface::instruction::initialize_mint(
+        &spl_token_interface::ID,
         &mint_account.pubkey(),
         &mint_authority.pubkey(),
         Some(&freeze_authority),
@@ -803,11 +803,11 @@ async fn withdraw_excess_lamports_from_mint_with_no_authority() {
 
     // And we remove the mint authority.
 
-    let set_authority_ix = spl_token::instruction::set_authority(
-        &spl_token::ID,
+    let set_authority_ix = spl_token_interface::instruction::set_authority(
+        &spl_token_interface::ID,
         &mint_account.pubkey(),
         None,
-        spl_token::instruction::AuthorityType::MintTokens,
+        spl_token_interface::instruction::AuthorityType::MintTokens,
         &mint_authority.pubkey(),
         &[&mint_authority.pubkey()],
     )
@@ -830,7 +830,7 @@ async fn withdraw_excess_lamports_from_mint_with_no_authority() {
     assert!(account.is_some());
 
     let account = account.unwrap();
-    let account = spl_token::state::Mint::unpack(&account.data).unwrap();
+    let account = spl_token_interface::state::Mint::unpack(&account.data).unwrap();
 
     assert!(account.mint_authority.is_none());
 
@@ -838,8 +838,8 @@ async fn withdraw_excess_lamports_from_mint_with_no_authority() {
 
     let destination = Pubkey::new_unique();
 
-    let mut withdraw_ix = spl_token_2022::instruction::withdraw_excess_lamports(
-        &spl_token_2022::ID,
+    let mut withdraw_ix = spl_token_2022_interface::instruction::withdraw_excess_lamports(
+        &spl_token_2022_interface::ID,
         &account_pubkey,
         &destination,
         &mint_account.pubkey(),
@@ -885,8 +885,8 @@ async fn fail_withdraw_excess_lamports_from_mint_with_authority_and_mint_as_sign
     let account_size = size_of::<Mint>();
     let rent = context.banks_client.get_rent().await.unwrap();
 
-    let initialize_ix = spl_token::instruction::initialize_mint(
-        &spl_token::ID,
+    let initialize_ix = spl_token_interface::instruction::initialize_mint(
+        &spl_token_interface::ID,
         &mint_account.pubkey(),
         &mint_authority.pubkey(),
         Some(&freeze_authority),
@@ -933,8 +933,8 @@ async fn fail_withdraw_excess_lamports_from_mint_with_authority_and_mint_as_sign
 
     let destination = Pubkey::new_unique();
 
-    let mut withdraw_ix = spl_token_2022::instruction::withdraw_excess_lamports(
-        &spl_token_2022::ID,
+    let mut withdraw_ix = spl_token_2022_interface::instruction::withdraw_excess_lamports(
+        &spl_token_2022_interface::ID,
         &account_pubkey,
         &destination,
         &mint_account.pubkey(),
@@ -985,8 +985,8 @@ async fn fail_withdraw_excess_lamports_from_mint_with_no_authority_and_authority
     let account_size = size_of::<Mint>();
     let rent = context.banks_client.get_rent().await.unwrap();
 
-    let initialize_ix = spl_token::instruction::initialize_mint(
-        &spl_token::ID,
+    let initialize_ix = spl_token_interface::instruction::initialize_mint(
+        &spl_token_interface::ID,
         &mint_account.pubkey(),
         &mint_authority.pubkey(),
         Some(&freeze_authority),
@@ -1031,11 +1031,11 @@ async fn fail_withdraw_excess_lamports_from_mint_with_no_authority_and_authority
 
     // And we remove the mint authority.
 
-    let set_authority_ix = spl_token::instruction::set_authority(
-        &spl_token::ID,
+    let set_authority_ix = spl_token_interface::instruction::set_authority(
+        &spl_token_interface::ID,
         &mint_account.pubkey(),
         None,
-        spl_token::instruction::AuthorityType::MintTokens,
+        spl_token_interface::instruction::AuthorityType::MintTokens,
         &mint_authority.pubkey(),
         &[&mint_authority.pubkey()],
     )
@@ -1058,7 +1058,7 @@ async fn fail_withdraw_excess_lamports_from_mint_with_no_authority_and_authority
     assert!(account.is_some());
 
     let account = account.unwrap();
-    let account = spl_token::state::Mint::unpack(&account.data).unwrap();
+    let account = spl_token_interface::state::Mint::unpack(&account.data).unwrap();
 
     assert!(account.mint_authority.is_none());
 
@@ -1066,8 +1066,8 @@ async fn fail_withdraw_excess_lamports_from_mint_with_no_authority_and_authority
 
     let destination = Pubkey::new_unique();
 
-    let mut withdraw_ix = spl_token_2022::instruction::withdraw_excess_lamports(
-        &spl_token_2022::ID,
+    let mut withdraw_ix = spl_token_2022_interface::instruction::withdraw_excess_lamports(
+        &spl_token_2022_interface::ID,
         &account_pubkey,
         &destination,
         &mint_authority.pubkey(),

--- a/program/src/error.rs
+++ b/program/src/error.rs
@@ -1,2 +1,6 @@
 //! Error types
+#![deprecated(
+    since = "8.1.0",
+    note = "Use spl_token_interface::error instead and remove spl_token as a dependency"
+)]
 pub use spl_token_interface::error::*;

--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -1,2 +1,6 @@
 //! Instruction types
+#![deprecated(
+    since = "8.1.0",
+    note = "Use spl_token_interface::instruction instead and remove spl_token as a dependency"
+)]
 pub use spl_token_interface::instruction::*;

--- a/program/src/native_mint.rs
+++ b/program/src/native_mint.rs
@@ -1,2 +1,6 @@
 //! The Mint that represents the native token
+#![deprecated(
+    since = "8.1.0",
+    note = "Use spl_token_interface::native_mint instead and remove spl_token as a dependency"
+)]
 pub use spl_token_interface::native_mint::*;

--- a/program/src/state.rs
+++ b/program/src/state.rs
@@ -1,2 +1,6 @@
 //! State transition types
+#![deprecated(
+    since = "8.1.0",
+    note = "Use spl_token_interface::state instead and remove spl_token as a dependency"
+)]
 pub use spl_token_interface::state::*;

--- a/program/tests/close_account.rs
+++ b/program/tests/close_account.rs
@@ -8,12 +8,12 @@ use {
     solana_pubkey::Pubkey,
     solana_sdk_ids::system_program,
     solana_system_interface::instruction::{create_account, transfer},
-    spl_token::{instruction, state::Account},
+    spl_token_interface::{instruction, state::Account},
 };
 
 #[test]
 fn success_init_after_close_account() {
-    let mollusk = Mollusk::new(&spl_token::id(), "spl_token");
+    let mollusk = Mollusk::new(&spl_token_interface::id(), "spl_token");
 
     let owner = Pubkey::new_unique();
     let mint = Pubkey::new_unique();
@@ -30,8 +30,14 @@ fn success_init_after_close_account() {
     mollusk.process_and_validate_instruction_chain(
         &[
             (
-                &instruction::close_account(&spl_token::id(), &account, &destination, &owner, &[])
-                    .unwrap(),
+                &instruction::close_account(
+                    &spl_token_interface::id(),
+                    &account,
+                    &destination,
+                    &owner,
+                    &[],
+                )
+                .unwrap(),
                 &[Check::success()],
             ),
             (
@@ -40,19 +46,24 @@ fn success_init_after_close_account() {
                     &account,
                     1_000_000_000,
                     Account::LEN as u64,
-                    &spl_token::id(),
+                    &spl_token_interface::id(),
                 ),
                 &[Check::success()],
             ),
             (
-                &instruction::initialize_account(&spl_token::id(), &account, &mint, &owner)
-                    .unwrap(),
+                &instruction::initialize_account(
+                    &spl_token_interface::id(),
+                    &account,
+                    &mint,
+                    &owner,
+                )
+                .unwrap(),
                 &[
                     Check::success(),
                     // Account successfully re-initialized.
                     Check::account(&account)
                         .data(setup::setup_token_account(&mint, &owner, 0).data())
-                        .owner(&spl_token::id())
+                        .owner(&spl_token_interface::id())
                         .build(),
                     // The destination should have the lamports from the closed account.
                     Check::account(&destination)
@@ -73,7 +84,7 @@ fn success_init_after_close_account() {
 
 #[test]
 fn fail_init_after_close_account() {
-    let mollusk = Mollusk::new(&spl_token::id(), "spl_token");
+    let mollusk = Mollusk::new(&spl_token_interface::id(), "spl_token");
 
     let owner = Pubkey::new_unique();
     let mint = Pubkey::new_unique();
@@ -90,8 +101,14 @@ fn fail_init_after_close_account() {
     mollusk.process_and_validate_instruction_chain(
         &[
             (
-                &instruction::close_account(&spl_token::id(), &account, &destination, &owner, &[])
-                    .unwrap(),
+                &instruction::close_account(
+                    &spl_token_interface::id(),
+                    &account,
+                    &destination,
+                    &owner,
+                    &[],
+                )
+                .unwrap(),
                 &[Check::success()],
             ),
             (
@@ -99,8 +116,13 @@ fn fail_init_after_close_account() {
                 &[Check::success()],
             ),
             (
-                &instruction::initialize_account(&spl_token::id(), &account, &mint, &owner)
-                    .unwrap(),
+                &instruction::initialize_account(
+                    &spl_token_interface::id(),
+                    &account,
+                    &mint,
+                    &owner,
+                )
+                .unwrap(),
                 &[
                     Check::err(ProgramError::InvalidAccountData),
                     // Account not re-initialized.

--- a/program/tests/processor.rs
+++ b/program/tests/processor.rs
@@ -40,7 +40,7 @@ fn do_process_instruction(
         .map(|(account_meta, account)| (account_meta.pubkey, (*account).clone()))
         .collect();
 
-    let mollusk = Mollusk::new(&spl_token::ID, "spl_token");
+    let mollusk = Mollusk::new(&spl_token_interface::ID, "spl_token");
     let result =
         mollusk.process_and_validate_instruction(&instruction, &instruction_accounts, checks);
 
@@ -82,7 +82,7 @@ fn do_process_instruction_dups(
         }
     });
 
-    let mollusk = Mollusk::new(&spl_token::ID, "spl_token");
+    let mollusk = Mollusk::new(&spl_token_interface::ID, "spl_token");
     let result = mollusk.process_and_validate_instruction(&instruction, &dedup_accounts, checks);
 
     // Update accounts after the instruction is processed.
@@ -129,7 +129,7 @@ fn multisig_minimum_balance() -> u64 {
 
 #[test]
 fn test_initialize_mint() {
-    let program_id = spl_token::id();
+    let program_id = spl_token_interface::id();
     let owner_key = Pubkey::new_unique();
     let mint_key = Pubkey::new_unique();
     let mut mint_account = SolanaAccount::new(42, Mint::get_packed_len(), &program_id);
@@ -191,7 +191,7 @@ fn test_initialize_mint() {
 
 #[test]
 fn test_initialize_mint2() {
-    let program_id = spl_token::id();
+    let program_id = spl_token_interface::id();
     let owner_key = Pubkey::new_unique();
     let mint_key = Pubkey::new_unique();
     let mut mint_account = SolanaAccount::new(42, Mint::get_packed_len(), &program_id);
@@ -252,7 +252,7 @@ fn test_initialize_mint2() {
 
 #[test]
 fn test_initialize_mint_account() {
-    let program_id = spl_token::id();
+    let program_id = spl_token_interface::id();
     let account_key = Pubkey::new_unique();
     let mut account_account = SolanaAccount::new(42, Account::get_packed_len(), &program_id);
     let owner_key = Pubkey::new_unique();
@@ -351,7 +351,7 @@ fn test_initialize_mint_account() {
 
 #[test]
 fn test_transfer_dups() {
-    let program_id = spl_token::id();
+    let program_id = spl_token_interface::id();
     let account1_key = Pubkey::new_unique();
     let mut account1_account = SolanaAccount::new(
         account_minimum_balance(),
@@ -675,7 +675,7 @@ fn test_transfer_dups() {
 
 #[test]
 fn test_transfer() {
-    let program_id = spl_token::id();
+    let program_id = spl_token_interface::id();
     let account_key = Pubkey::new_unique();
     let mut account_account = SolanaAccount::new(
         account_minimum_balance(),
@@ -1196,7 +1196,7 @@ fn test_transfer() {
 
 #[test]
 fn test_self_transfer() {
-    let program_id = spl_token::id();
+    let program_id = spl_token_interface::id();
     let account_key = Pubkey::new_unique();
     let mut account_account = SolanaAccount::new(
         account_minimum_balance(),
@@ -1767,7 +1767,7 @@ fn test_self_transfer() {
 
 #[test]
 fn test_mintable_token_with_zero_supply() {
-    let program_id = spl_token::id();
+    let program_id = spl_token_interface::id();
     let account_key = Pubkey::new_unique();
     let mut account_account = SolanaAccount::new(
         account_minimum_balance(),
@@ -1889,7 +1889,7 @@ fn test_mintable_token_with_zero_supply() {
 
 #[test]
 fn test_approve_dups() {
-    let program_id = spl_token::id();
+    let program_id = spl_token_interface::id();
     let account1_key = Pubkey::new_unique();
     let mut account1_account = SolanaAccount::new(
         account_minimum_balance(),
@@ -2113,7 +2113,7 @@ fn test_approve_dups() {
 
 #[test]
 fn test_approve() {
-    let program_id = spl_token::id();
+    let program_id = spl_token_interface::id();
     let account_key = Pubkey::new_unique();
     let mut account_account = SolanaAccount::new(
         account_minimum_balance(),
@@ -2329,7 +2329,7 @@ fn test_approve() {
 
 #[test]
 fn test_set_authority_dups() {
-    let program_id = spl_token::id();
+    let program_id = spl_token_interface::id();
     let account1_key = Pubkey::new_unique();
     let mut account1_account = SolanaAccount::new(
         account_minimum_balance(),
@@ -2438,7 +2438,7 @@ fn test_set_authority_dups() {
 
 #[test]
 fn test_set_authority() {
-    let program_id = spl_token::id();
+    let program_id = spl_token_interface::id();
     let account_key = Pubkey::new_unique();
     let mut account_account = SolanaAccount::new(
         account_minimum_balance(),
@@ -2873,7 +2873,7 @@ fn test_set_authority() {
 
 #[test]
 fn test_mint_to_dups() {
-    let program_id = spl_token::id();
+    let program_id = spl_token_interface::id();
     let account1_key = Pubkey::new_unique();
     let mut account1_account = SolanaAccount::new(
         account_minimum_balance(),
@@ -2975,7 +2975,7 @@ fn test_mint_to_dups() {
 
 #[test]
 fn test_mint_to() {
-    let program_id = spl_token::id();
+    let program_id = spl_token_interface::id();
     let account_key = Pubkey::new_unique();
     let mut account_account = SolanaAccount::new(
         account_minimum_balance(),
@@ -3233,7 +3233,7 @@ fn test_mint_to() {
 
 #[test]
 fn test_burn_dups() {
-    let program_id = spl_token::id();
+    let program_id = spl_token_interface::id();
     let account1_key = Pubkey::new_unique();
     let mut account1_account = SolanaAccount::new(
         account_minimum_balance(),
@@ -3447,7 +3447,7 @@ fn test_burn_dups() {
 
 #[test]
 fn test_burn() {
-    let program_id = spl_token::id();
+    let program_id = spl_token_interface::id();
     let account_key = Pubkey::new_unique();
     let mut account_account = SolanaAccount::new(
         account_minimum_balance(),
@@ -3778,7 +3778,7 @@ fn test_burn() {
 
 #[test]
 fn test_burn_and_close_system_and_incinerator_tokens() {
-    let program_id = spl_token::id();
+    let program_id = spl_token_interface::id();
     let account_key = Pubkey::new_unique();
     let mut account_account = SolanaAccount::new(
         account_minimum_balance(),
@@ -4052,7 +4052,7 @@ fn test_burn_and_close_system_and_incinerator_tokens() {
 
 #[test]
 fn test_multisig() {
-    let program_id = spl_token::id();
+    let program_id = spl_token_interface::id();
     let mint_key = Pubkey::new_unique();
     let mut mint_account =
         SolanaAccount::new(mint_minimum_balance(), Mint::get_packed_len(), &program_id);
@@ -4485,7 +4485,7 @@ fn test_multisig() {
 
 #[test]
 fn test_owner_close_account_dups() {
-    let program_id = spl_token::id();
+    let program_id = spl_token_interface::id();
     let owner_key = Pubkey::new_unique();
     let mint_key = Pubkey::new_unique();
     let mut mint_account =
@@ -4557,7 +4557,7 @@ fn test_owner_close_account_dups() {
 
 #[test]
 fn test_close_authority_close_account_dups() {
-    let program_id = spl_token::id();
+    let program_id = spl_token_interface::id();
     let owner_key = Pubkey::new_unique();
     let mint_key = Pubkey::new_unique();
     let mut mint_account =
@@ -4631,7 +4631,7 @@ fn test_close_authority_close_account_dups() {
 
 #[test]
 fn test_close_account() {
-    let program_id = spl_token::id();
+    let program_id = spl_token_interface::id();
     let mint_key = Pubkey::new_unique();
     let mut mint_account =
         SolanaAccount::new(mint_minimum_balance(), Mint::get_packed_len(), &program_id);
@@ -4715,7 +4715,7 @@ fn test_close_account() {
         initialize_account(
             &program_id,
             &account2_key,
-            &spl_token::native_mint::id(),
+            &spl_token_interface::native_mint::id(),
             &owner_key,
         )
         .unwrap(),
@@ -4907,7 +4907,7 @@ fn test_close_account() {
 
 #[test]
 fn test_native_token() {
-    let program_id = spl_token::id();
+    let program_id = spl_token_interface::id();
     let mut mint_account =
         SolanaAccount::new(mint_minimum_balance(), Mint::get_packed_len(), &program_id);
     let account_key = Pubkey::new_unique();
@@ -4936,7 +4936,7 @@ fn test_native_token() {
         initialize_account(
             &program_id,
             &account_key,
-            &spl_token::native_mint::id(),
+            &spl_token_interface::native_mint::id(),
             &owner_key,
         )
         .unwrap(),
@@ -4966,7 +4966,7 @@ fn test_native_token() {
         initialize_account(
             &program_id,
             &account2_key,
-            &spl_token::native_mint::id(),
+            &spl_token_interface::native_mint::id(),
             &owner_key,
         )
         .unwrap(),
@@ -4997,7 +4997,7 @@ fn test_native_token() {
         do_process_instruction(
             mint_to(
                 &program_id,
-                &spl_token::native_mint::id(),
+                &spl_token_interface::native_mint::id(),
                 &account_key,
                 &owner_key,
                 &[],
@@ -5187,7 +5187,7 @@ fn test_native_token() {
 
 #[test]
 fn test_overflow() {
-    let program_id = spl_token::id();
+    let program_id = spl_token_interface::id();
     let account_key = Pubkey::new_unique();
     let mut account_account = SolanaAccount::new(
         account_minimum_balance(),
@@ -5367,7 +5367,7 @@ fn test_overflow() {
 
 #[test]
 fn test_frozen() {
-    let program_id = spl_token::id();
+    let program_id = spl_token_interface::id();
     let account_key = Pubkey::new_unique();
     let mut account_account = SolanaAccount::new(
         account_minimum_balance(),
@@ -5564,7 +5564,7 @@ fn test_frozen() {
 
 #[test]
 fn test_freeze_thaw_dups() {
-    let program_id = spl_token::id();
+    let program_id = spl_token_interface::id();
     let account1_key = Pubkey::new_unique();
     let mut account1_account = SolanaAccount::new(
         account_minimum_balance(),
@@ -5632,7 +5632,7 @@ fn test_freeze_thaw_dups() {
 
 #[test]
 fn test_freeze_account() {
-    let program_id = spl_token::id();
+    let program_id = spl_token_interface::id();
     let account_key = Pubkey::new_unique();
     let mut account_account = SolanaAccount::new(
         account_minimum_balance(),
@@ -5765,7 +5765,7 @@ fn test_freeze_account() {
 
 #[test]
 fn test_initialize_account2_and_3() {
-    let program_id = spl_token::id();
+    let program_id = spl_token_interface::id();
     let account_key = Pubkey::new_unique();
     let mut account_account = SolanaAccount::new(
         account_minimum_balance(),
@@ -5830,7 +5830,7 @@ fn test_initialize_account2_and_3() {
 
 #[test]
 fn test_sync_native() {
-    let program_id = spl_token::id();
+    let program_id = spl_token_interface::id();
     let mint_key = Pubkey::new_unique();
     let mut mint_account =
         SolanaAccount::new(mint_minimum_balance(), Mint::get_packed_len(), &program_id);
@@ -5910,7 +5910,7 @@ fn test_sync_native() {
         initialize_account(
             &program_id,
             &native_account_key,
-            &spl_token::native_mint::id(),
+            &spl_token_interface::native_mint::id(),
             &owner_key,
         )
         .unwrap(),
@@ -6001,7 +6001,7 @@ fn test_sync_native() {
 #[serial]
 fn test_get_account_data_size() {
     // see integration tests for return-data validity
-    let program_id = spl_token::id();
+    let program_id = spl_token_interface::id();
     let owner_key = Pubkey::new_unique();
     let mut rent_sysvar = rent_sysvar();
     let mut mint_account =
@@ -6037,7 +6037,7 @@ fn test_get_account_data_size() {
 
 #[test]
 fn test_initialize_immutable_owner() {
-    let program_id = spl_token::id();
+    let program_id = spl_token_interface::id();
     let account_key = Pubkey::new_unique();
     let mut account_account = SolanaAccount::new(
         account_minimum_balance(),
@@ -6094,7 +6094,7 @@ fn test_initialize_immutable_owner() {
 #[test]
 #[serial]
 fn test_amount_to_ui_amount() {
-    let program_id = spl_token::id();
+    let program_id = spl_token_interface::id();
     let owner_key = Pubkey::new_unique();
     let mint_key = Pubkey::new_unique();
     let mut mint_account =
@@ -6151,7 +6151,7 @@ fn test_amount_to_ui_amount() {
 #[test]
 #[serial]
 fn test_ui_amount_to_amount() {
-    let program_id = spl_token::id();
+    let program_id = spl_token_interface::id();
     let owner_key = Pubkey::new_unique();
     let mint_key = Pubkey::new_unique();
     let mut mint_account =

--- a/program/tests/setup.rs
+++ b/program/tests/setup.rs
@@ -3,7 +3,7 @@ use {
     solana_program_pack::Pack,
     solana_pubkey::Pubkey,
     solana_rent::Rent,
-    spl_token::state::{Account, AccountState, Mint},
+    spl_token_interface::state::{Account, AccountState, Mint},
 };
 
 pub fn setup_mint_account(
@@ -31,7 +31,7 @@ pub fn setup_mint_account(
     SolanaAccount {
         lamports,
         data,
-        owner: spl_token::id(),
+        owner: spl_token_interface::id(),
         ..Default::default()
     }
 }
@@ -59,7 +59,7 @@ pub fn setup_token_account(mint: &Pubkey, owner: &Pubkey, amount: u64) -> Solana
     SolanaAccount {
         lamports,
         data,
-        owner: spl_token::id(),
+        owner: spl_token_interface::id(),
         ..Default::default()
     }
 }


### PR DESCRIPTION
#### Problem

We need pepole to know about spl-token-interface so they can start using it, but we haven't really promoted it.

#### Summary of changes

Do the right thing, and make the deprecations loud in spl-token, and stop using spl-token's re-exports everywhere in the repo.