### PR TITLE
CI: Fix publish tool versions

### DIFF
--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -88,7 +88,7 @@ jobs:
       - name: Install cargo-semver-checks
         uses: taiki-e/install-action@v2
         with:
-          tool: cargo-semver-checks,cargo-release
+          tool: cargo-semver-checks@0.42.0,cargo-release@0.25.18
 
       - name: Set Git Author (required for cargo-release)
         run: |
@@ -129,7 +129,7 @@ jobs:
       - name: Install cargo-release
         uses: taiki-e/install-action@v2
         with:
-          tool: cargo-release
+          tool: cargo-release@0.25.18
 
       - name: Ensure CARGO_REGISTRY_TOKEN variable is set
         env:


### PR DESCRIPTION
#### Problem

The publish job is failing because the newest semver-checks doesn't support Rust 1.86.

#### Summary of changes

Similar to the reusable action, fix cargo-semver-checks and cargo-release to appropriate versions.