### PR TITLE
CI: Require TOML to be formatted

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -19,6 +19,9 @@ inputs:
   rustfmt:
     description: Install Rustfmt if `true`. Defaults to `false`.
     required: false
+  tombi:
+    description: Install tombi if `true`. Defaults to `false`.
+    required: false
   solana:
     description: Install Solana if `true`. Defaults to `false`.
     required: false
@@ -94,6 +97,10 @@ runs:
       with:
         toolchain: ${{ env.TOOLCHAIN_LINT }}
         components: clippy
+
+    - name: Install tombi
+      if: ${{ inputs.tombi == 'true' }}
+      uses: tombi-toml/setup-tombi@v1
 
     - name: Install Solana
       if: ${{ inputs.solana == 'true' }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,6 +22,24 @@ jobs:
       - name: Lint Client JS
         run: pnpm clients:js:lint
 
+  format_and_lint_workspace_toml:
+    name: Format & Lint workspace level Toml
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Environment
+        uses: ./.github/actions/setup
+        with:
+          tombi: true
+
+      - name: Format workspace level Toml
+        run: pnpm workspace:toml:format
+
+      - name: Lint workspace level Toml
+        run: pnpm workspace:toml:lint
+
   format_and_lint_client_rust:
     if: false # Disabled until we have a Rust client
     name: Format & Lint Client Rust
@@ -35,6 +53,7 @@ jobs:
         with:
           clippy: true
           rustfmt: true
+          tombi: true
 
       - name: Format Client Rust
         run: pnpm clients:rust:format
@@ -54,6 +73,7 @@ jobs:
         with:
           clippy: true
           rustfmt: true
+          tombi: true
 
       - name: Format
         run: pnpm programs:format
@@ -73,6 +93,7 @@ jobs:
         with:
           clippy: true
           rustfmt: true
+          tombi: true
 
       - name: Format
         run: pnpm p-interface:format
@@ -92,6 +113,7 @@ jobs:
         with:
           clippy: true
           rustfmt: true
+          tombi: true
 
       - name: Format
         run: pnpm p-token:format
@@ -111,6 +133,7 @@ jobs:
         with:
           clippy: true
           rustfmt: true
+          tombi: true
 
       - name: Format
         run: pnpm interface:format

--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -56,6 +56,7 @@ jobs:
         with:
           clippy: true
           rustfmt: true
+          tombi: true
           solana: true
           cargo-cache-key: cargo-test-publish-${{ inputs.package_path }}
           cargo-cache-fallback-key: cargo-test-publish
@@ -65,6 +66,12 @@ jobs:
 
       - name: Lint
         run: pnpm zx ./scripts/rust/lint.mjs "${{ inputs.package_path }}"
+
+      - name: Format Toml
+        run: pnpm zx ./scripts/toml/format.mjs "${{ inputs.package_path }}"
+
+      - name: Lint Toml
+        run: pnpm zx ./scripts/toml/lint.mjs "${{ inputs.package_path }}"
 
       - name: Build programs
         run: pnpm programs:build

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,15 +4,27 @@ members = ["interface", "pinocchio/interface", "pinocchio/program", "program"]
 
 [workspace.package]
 authors = ["Anza Maintainers <maintainers@anza.xyz>"]
+edition = "2021"
 repository = "https://github.com/solana-program/token"
 license = "Apache-2.0"
-edition = "2021"
+
+[workspace.dependencies]
+mollusk-svm = "0.6.3"
+mollusk-svm-fuzz-fixture = "0.6.3"
+num-traits = "0.2"
+pinocchio = "0.9.2"
+solana-instruction = "3.0.0"
+solana-program-error = "3.0.0"
+solana-program-option = "3.0.0"
+solana-program-pack = "3.0.0"
+solana-pubkey = "3.0.0"
+solana-system-interface = { version = "2.0", features = ["bincode"] }
 
 [workspace.lints.rust.unexpected_cfgs]
 level = "warn"
 check-cfg = [
-    'cfg(target_os, values("solana"))',
-    'cfg(feature, values("custom-alloc", "custom-panic", "frozen-abi", "no-entrypoint"))',
+  'cfg(target_os, values("solana"))',
+  'cfg(feature, values("custom-alloc", "custom-panic", "frozen-abi", "no-entrypoint"))',
 ]
 
 [workspace.metadata.cli]
@@ -31,15 +43,3 @@ config = "scripts/spellcheck.toml"
 pre-release-commit-message = "Publish {{crate_name}} v{{version}}"
 tag-message = "Publish {{crate_name}} v{{version}}"
 consolidate-commits = false
-
-[workspace.dependencies]
-mollusk-svm = "0.6.3"
-mollusk-svm-fuzz-fixture = "0.6.3"
-num-traits = "0.2"
-pinocchio = "0.9.2"
-solana-instruction = "3.0.0"
-solana-program-error = "3.0.0"
-solana-program-option = "3.0.0"
-solana-program-pack = "3.0.0"
-solana-pubkey = "3.0.0"
-solana-system-interface = { version = "2.0", features=["bincode"] }

--- a/clients/rust/Cargo.toml
+++ b/clients/rust/Cargo.toml
@@ -1,15 +1,11 @@
 [package]
 name = "spl-token-client"
 version = "0.0.0"
-description = "A generated Rust library for the Token program"
-repository = "https://github.com/solana-program/token"
 edition = "2021"
+description = "A generated Rust library for the Token program"
 readme = "README.md"
+repository = "https://github.com/solana-program/token"
 license-file = "../../LICENSE"
-
-[features]
-test-sbf = []
-serde = ["dep:serde", "dep:serde_with"]
 
 [dependencies]
 borsh = "^0.10"
@@ -19,3 +15,7 @@ serde = { version = "^1.0", features = ["derive"], optional = true }
 serde_with = { version = "^3.0", optional = true }
 solana-program = "2.1"
 thiserror = "^1.0"
+
+[features]
+serde = ["dep:serde", "dep:serde_with"]
+test-sbf = []

--- a/interface/Cargo.toml
+++ b/interface/Cargo.toml
@@ -1,13 +1,22 @@
 [package]
 name = "spl-token-interface"
 version = "2.0.0"
+authors = { workspace = true }
+edition = { workspace = true }
 description = "Solana Program Library Token Interface"
 documentation = "https://docs.rs/spl-token-interface"
 readme = "README.md"
-authors = { workspace = true }
 repository = { workspace = true }
 license = { workspace = true }
-edition = { workspace = true }
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[package.metadata.solana]
+program-id = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+
+[lib]
+crate-type = ["lib"]
 
 [dependencies]
 arrayref = "0.3.9"
@@ -28,14 +37,5 @@ proptest = "1.5"
 strum = "0.24"
 strum_macros = "0.24"
 
-[lib]
-crate-type = ["lib"]
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]
-
 [lints]
 workspace = true
-
-[package.metadata.solana]
-program-id = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,8 @@
 {
   "private": true,
   "scripts": {
+    "workspace:toml:format": "zx ./scripts/toml/format.mjs Cargo.toml rust-toolchain.toml rustfmt.toml scripts/spellcheck.toml",
+    "workspace:toml:lint": "zx ./scripts/toml/lint.mjs Cargo.toml rust-toolchain.toml rustfmt.toml scripts/spellcheck.toml",
     "programs:build": "zx ./scripts/rust/build-sbf.mjs program",
     "programs:format": "zx ./scripts/rust/format.mjs program",
     "programs:lint": "zx ./scripts/rust/lint.mjs program",

--- a/pinocchio/interface/Cargo.toml
+++ b/pinocchio/interface/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "pinocchio-token-interface"
 version = "0.0.0"
+authors = { workspace = true }
+edition = { workspace = true }
 description = "Pinocchio instructions and types for interacting with SPL Token program"
-authors = { workspace = true}
-repository = { workspace = true}
-license = { workspace = true}
-edition = { workspace = true}
 readme = "./README.md"
+repository = { workspace = true }
+license = { workspace = true }
 
 [lib]
 crate-type = ["rlib"]

--- a/pinocchio/program/Cargo.toml
+++ b/pinocchio/program/Cargo.toml
@@ -1,23 +1,20 @@
 [package]
 name = "pinocchio-token-program"
 version = "0.0.0"
+authors = { workspace = true }
+edition = { workspace = true }
 description = "A pinocchio-based Token (aka 'p-token') program"
-authors = { workspace = true}
-repository = { workspace = true}
-license = { workspace = true}
-edition = { workspace = true}
 readme = "./README.md"
+repository = { workspace = true }
+license = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]
 
-[features]
-logging = []
-
 [dependencies]
 pinocchio = { workspace = true }
 pinocchio-log = { version = "0.5.1", default-features = false }
-pinocchio-token-interface = { version = "^0", path = "../interface" }
+pinocchio-token-interface = { path = "../interface", version = "^0" }
 
 [dev-dependencies]
 agave-feature-set = "3.0.0"
@@ -37,11 +34,14 @@ solana-rent = "3.0.0"
 solana-sdk-ids = "3.0.0"
 solana-signature = "3.0.0"
 solana-signer = "3.0.0"
+solana-system-interface = { workspace = true }
 solana-transaction = "3.0.0"
 solana-transaction-error = "3.0.0"
-solana-system-interface = { workspace = true }
-spl-token-interface = "2"
 spl-token-2022-interface = "2"
+spl-token-interface = "2"
+
+[features]
+logging = []
 
 [lints]
 workspace = true

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -1,22 +1,27 @@
 [package]
 name = "spl-token"
 version = "9.0.0"
+authors = { workspace = true }
+edition = { workspace = true }
 description = "Solana Program Library Token"
-authors = { workspace = true}
-repository = { workspace = true}
-license = { workspace = true}
-edition = { workspace = true}
+repository = { workspace = true }
+license = { workspace = true }
 
-[features]
-no-entrypoint = []
-test-sbf = []
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[package.metadata.solana]
+program-id = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+
+[lib]
+crate-type = ["cdylib", "lib"]
 
 [dependencies]
 arrayref = "0.3.9"
 bytemuck = "1.20.0"
 num-derive = "0.4"
-num-traits = { workspace = true }
 num_enum = "0.7.3"
+num-traits = { workspace = true }
 solana-account-info = "3.0.0"
 solana-cpi = "3.0.0"
 solana-instruction = { workspace = true }
@@ -44,18 +49,13 @@ solana-account-info = "3.0.0"
 solana-clock = "3.0.0"
 solana-native-token = "3.0.0"
 solana-rent = { version = "3.0.0", features = ["sysvar"] }
-solana-system-interface = { version = "2.0", features=["bincode"] }
+solana-system-interface = { version = "2.0", features = ["bincode"] }
 strum = "0.24"
 strum_macros = "0.24"
 
-[lib]
-crate-type = ["cdylib", "lib"]
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]
+[features]
+no-entrypoint = []
+test-sbf = []
 
 [lints]
 workspace = true
-
-[package.metadata.solana]
-program-id = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"

--- a/scripts/rust/format.mjs
+++ b/scripts/rust/format.mjs
@@ -18,7 +18,9 @@ const manifestPath = path.join(workingDirectory, folder, 'Cargo.toml');
 
 // Format the client.
 if (fix) {
+  await $`tombi format ${formatArgs} ${folder}`;
   await $`cargo ${toolchain} fmt --manifest-path ${manifestPath} ${cargoArgs} -- ${fmtArgs}`;
 } else {
+  await $`tombi lint ${formatArgs} ${folder}`;
   await $`cargo ${toolchain} fmt --manifest-path ${manifestPath} ${cargoArgs} -- --check ${fmtArgs}`;
 }

--- a/scripts/spellcheck.toml
+++ b/scripts/spellcheck.toml
@@ -3,4 +3,3 @@ use_builtin = true
 skip_os_lookups = false
 search_dirs = ["."]
 extra_dictionaries = ["solana.dic"]
-

--- a/scripts/toml/format.mjs
+++ b/scripts/toml/format.mjs
@@ -1,0 +1,13 @@
+#!/usr/bin/env zx
+import 'zx/globals';
+import { cliArguments, popArgument } from '../utils.mjs';
+
+const args = cliArguments();
+
+const fix = popArgument(args, '--fix');
+
+if (fix) {
+  await $`tombi format ${args}`;
+} else {
+  await $`tombi format --check ${args}`;
+}

--- a/scripts/toml/lint.mjs
+++ b/scripts/toml/lint.mjs
@@ -1,0 +1,7 @@
+#!/usr/bin/env zx
+import 'zx/globals';
+import { cliArguments } from '../utils.mjs';
+
+const args = cliArguments();
+
+await $`tombi lint ${args}`;


### PR DESCRIPTION
tombi is a pretty good TOML formatter/LSP with support for TOML in general, and Rust Cargo.toml in particular.

Using a unified format is nice.

In particular, tombi sorts not just properties within a section, but also sections and tables.  Apparently some TOML parsers may fail if tables are not correctly sorted.