### PR TITLE
Add an instruction plan for creating a mint

### DIFF
--- a/clients/js/src/createMint.ts
+++ b/clients/js/src/createMint.ts
@@ -1,0 +1,71 @@
+import { getCreateAccountInstruction } from '@solana-program/system';
+import {
+  Address,
+  InstructionPlan,
+  OptionOrNullable,
+  sequentialInstructionPlan,
+  TransactionSigner,
+} from '@solana/kit';
+import {
+  getInitializeMint2Instruction,
+  getMintSize,
+  TOKEN_PROGRAM_ADDRESS,
+} from './generated';
+
+// RPC `getMinimumBalanceForRentExemption` for 82 bytes, which is token mint size
+// Hardcoded to avoid requiring an RPC request each time
+const MINIMUM_BALANCE_FOR_MINT = 1461600;
+
+export type CreateMintInstructionPlanInput = {
+  /** Funding account (must be a system account). */
+  payer: TransactionSigner;
+  /** New mint account to create. */
+  newMint: TransactionSigner;
+  /** Number of base 10 digits to the right of the decimal place. */
+  decimals: number;
+  /** The authority/multisignature to mint tokens. */
+  mintAuthority: Address;
+  /** The optional freeze authority/multisignature of the mint. */
+  freezeAuthority?: OptionOrNullable<Address>;
+  /**
+   * Optional override for the amount of Lamports to fund the mint account with.
+   * @default 1461600
+   *  */
+  mintAccountLamports?: number;
+};
+
+type CreateMintInstructionPlanConfig = {
+  systemProgramAddress?: Address;
+  tokenProgramAddress?: Address;
+};
+
+export function createMintInstructionPlan(
+  params: CreateMintInstructionPlanInput,
+  config?: CreateMintInstructionPlanConfig
+): InstructionPlan {
+  return sequentialInstructionPlan([
+    getCreateAccountInstruction(
+      {
+        payer: params.payer,
+        newAccount: params.newMint,
+        lamports: params.mintAccountLamports ?? MINIMUM_BALANCE_FOR_MINT,
+        space: getMintSize(),
+        programAddress: config?.tokenProgramAddress ?? TOKEN_PROGRAM_ADDRESS,
+      },
+      {
+        programAddress: config?.systemProgramAddress,
+      }
+    ),
+    getInitializeMint2Instruction(
+      {
+        mint: params.newMint.address,
+        decimals: params.decimals,
+        mintAuthority: params.mintAuthority,
+        freezeAuthority: params.freezeAuthority,
+      },
+      {
+        programAddress: config?.tokenProgramAddress,
+      }
+    ),
+  ]);
+}

--- a/clients/js/src/index.ts
+++ b/clients/js/src/index.ts
@@ -1,1 +1,2 @@
 export * from './generated';
+export * from './createMint';

--- a/clients/js/test/createMint.test.ts
+++ b/clients/js/test/createMint.test.ts
@@ -1,0 +1,77 @@
+import { generateKeyPairSigner, Account, some, none } from '@solana/kit';
+import test from 'ava';
+import { fetchMint, Mint, createMintInstructionPlan } from '../src';
+import {
+  createDefaultSolanaClient,
+  generateKeyPairSignerWithSol,
+  createDefaultTransactionPlanner,
+  createDefaultTransactionPlanExecutor,
+} from './_setup';
+
+test('it creates and initializes a new mint account', async (t) => {
+  // Given an authority and a mint account.
+  const client = createDefaultSolanaClient();
+  const authority = await generateKeyPairSignerWithSol(client);
+  const mint = await generateKeyPairSigner();
+
+  // When we create and initialize a mint account at this address.
+  const instructionPlan = createMintInstructionPlan({
+    payer: authority,
+    newMint: mint,
+    decimals: 2,
+    mintAuthority: authority.address,
+  });
+
+  const transactionPlanner = createDefaultTransactionPlanner(client, authority);
+  const transactionPlan = await transactionPlanner(instructionPlan);
+  const transactionPlanExecutor = createDefaultTransactionPlanExecutor(client);
+  await transactionPlanExecutor(transactionPlan);
+
+  // Then we expect the mint account to exist and have the following data.
+  const mintAccount = await fetchMint(client.rpc, mint.address);
+  t.like(mintAccount, <Account<Mint>>{
+    address: mint.address,
+    data: {
+      mintAuthority: some(authority.address),
+      supply: 0n,
+      decimals: 2,
+      isInitialized: true,
+      freezeAuthority: none(),
+    },
+  });
+});
+
+test('it creates a new mint account with a freeze authority', async (t) => {
+  // Given an authority and a mint account.
+  const client = createDefaultSolanaClient();
+  const [payer, mintAuthority, freezeAuthority, mint] = await Promise.all([
+    generateKeyPairSignerWithSol(client),
+    generateKeyPairSigner(),
+    generateKeyPairSigner(),
+    generateKeyPairSigner(),
+  ]);
+
+  // When we create and initialize a mint account at this address.
+  const instructionPlan = createMintInstructionPlan({
+    payer: payer,
+    newMint: mint,
+    decimals: 2,
+    mintAuthority: mintAuthority.address,
+    freezeAuthority: freezeAuthority.address,
+  });
+
+  const transactionPlanner = createDefaultTransactionPlanner(client, payer);
+  const transactionPlan = await transactionPlanner(instructionPlan);
+  const transactionPlanExecutor = createDefaultTransactionPlanExecutor(client);
+  await transactionPlanExecutor(transactionPlan);
+
+  // Then we expect the mint account to exist and have the following data.
+  const mintAccount = await fetchMint(client.rpc, mint.address);
+  t.like(mintAccount, <Account<Mint>>{
+    address: mint.address,
+    data: {
+      mintAuthority: some(mintAuthority.address),
+      freezeAuthority: some(freezeAuthority.address),
+    },
+  });
+});


### PR DESCRIPTION
This PR adds a new instruction plan to create a mint. This combines the `createAccount` instruction from the system program, with the `initializeMint2` instruction from the token program.

I've structured it to take input in a similar way to generated instructions.

I've also added test helpers for a transaction plan/executor, using the same behaviour as the existing test helpers.

Example:
```ts
const instructionPlan = getCreateMintInstructionPlan({
    payer: authority,
    newMint: mint,
    decimals: 2,
    mintAuthority: authority.address,
});

const transactionPlan = await transactionPlanner(instructionPlan);
await transactionPlanExecutor(transactionPlan);
```