### PR TITLE
p-interface: Fix try_from for TokenInstruction

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,8 +61,8 @@ jobs:
       - name: Lint
         run: pnpm programs:lint
 
-  format_and_lint_pinterface:
-    name: Format & Lint P-Interface
+  format_lint_and_test_pinterface:
+    name: Format, Lint & Test P-Interface
     runs-on: ubuntu-latest
     steps:
       - name: Git Checkout
@@ -79,6 +79,9 @@ jobs:
 
       - name: Lint
         run: pnpm p-interface:lint
+
+      - name: Test
+        run: pnpm p-interface:test
 
   format_and_lint_ptoken:
     name: Format & Lint p-token
@@ -99,7 +102,7 @@ jobs:
       - name: Lint
         run: pnpm p-token:lint
 
-  format_and_lint_interface:
+  format_lint_and_test_interface:
     name: Format, Lint & Test Interface
     runs-on: ubuntu-latest
     steps:
@@ -118,7 +121,7 @@ jobs:
       - name: Lint
         run: pnpm interface:lint
 
-      - name: Lint
+      - name: Test
         run: pnpm interface:test
 
   audit_rust:
@@ -214,7 +217,7 @@ jobs:
   build_ptoken:
     name: Build p-token
     runs-on: ubuntu-latest
-    needs: [format_and_lint_pinterface, format_and_lint_ptoken]
+    needs: [format_lint_and_test_pinterface, format_and_lint_ptoken]
     steps:
       - name: Git Checkout
         uses: actions/checkout@v4

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "fixtures:run": "zx ./scripts/rust/fixtures.mjs run",
     "p-interface:format": "zx ./scripts/rust/format.mjs pinocchio/interface",
     "p-interface:lint": "zx ./scripts/rust/lint.mjs pinocchio/interface",
+    "p-interface:test": "zx ./scripts/rust/test.mjs pinocchio/interface",
     "interface:format": "zx ./scripts/rust/format.mjs interface",
     "interface:lint": "zx ./scripts/rust/lint.mjs interface",
     "interface:test": "zx ./scripts/rust/test.mjs interface"

--- a/pinocchio/interface/src/instruction.rs
+++ b/pinocchio/interface/src/instruction.rs
@@ -547,7 +547,7 @@ impl TryFrom<u8> for TokenInstruction {
     fn try_from(value: u8) -> Result<Self, Self::Error> {
         match value {
             // SAFETY: `value` is guaranteed to be in the range of the enum variants.
-            0..=24 | 38 | 255 => Ok(unsafe { core::mem::transmute::<u8, TokenInstruction>(value) }),
+            0..=24 | 38 | 45 | 255 => Ok(unsafe { core::mem::transmute::<u8, TokenInstruction>(value) }),
             _ => Err(TokenError::InvalidInstruction.into()),
         }
     }


### PR DESCRIPTION
### Problem
The enum variant `UnwrapLamports = 45` is not present in the `try_from` function for the `TokenInstruction` of the p-interface.

### Solution
Add `45` to the match branch. Also, add p-interface tests to CI to catch such errors in the future.