### PR TITLE
pinocchio-interface: include UnwrapLamports (45) in TokenInstruction::try_from

### DIFF
--- a/pinocchio/interface/src/instruction.rs
+++ b/pinocchio/interface/src/instruction.rs
@@ -601,7 +601,7 @@ mod tests {
             assert_eq!(TokenInstruction::try_from(variant_u8).unwrap(), variant);
         }
     }
- 
+
     #[test]
     fn test_authority_type_from_u8_exhaustive() {
         for variant in AuthorityType::iter() {


### PR DESCRIPTION
The TryFrom<u8> implementation for TokenInstruction was missing the
UnwrapLamports = 45 variant, causing
test_token_instruction_from_u8_exhaustive to fail.

This PR adds the missing variant to keep the conversion logic in sync with
the enum definition.