### PR TITLE
p-token: Expand comments

### DIFF
--- a/pinocchio/interface/src/error.rs
+++ b/pinocchio/interface/src/error.rs
@@ -27,6 +27,9 @@ pub enum TokenError {
     /// Invalid number of required signers.
     InvalidNumberOfRequiredSigners,
     /// State is uninitialized.
+    ///
+    /// This error is not currently returned by the program and is reserved
+    /// for compatibility.
     UninitializedState,
 
     // 10

--- a/pinocchio/interface/src/instruction.rs
+++ b/pinocchio/interface/src/instruction.rs
@@ -134,6 +134,9 @@ pub enum TokenInstruction {
 
     /// Sets a new authority of a mint or account.
     ///
+    /// Note that when setting a new account owner authority on a native
+    /// token account, the current close authority (if any) will be removed.
+    ///
     /// Accounts expected by this instruction:
     ///
     ///   * Single authority
@@ -550,7 +553,15 @@ pub enum TokenInstruction {
     ///
     /// Both the number of accounts and instruction data length are used to
     /// identify the slice of accounts and instruction data for each
-    /// instruction.
+    /// instruction. Since the instruction data length is specified as a `u8`,
+    /// the maximum instruction data length is 255 bytes, which is sufficient
+    /// for all current instructions in the program.
+    ///
+    /// When one or more batched instructions write return data, the batch
+    /// instruction returns the data written by the last instruction that does
+    /// so. That instruction does not have to be the final instruction in the
+    /// batch: later instructions that do not write return data leave the last
+    /// written return data unchanged.
     ///
     /// Note that it is not sound to have a `batch` instruction that contains
     /// other `batch` instruction; an error will be raised when this is

--- a/pinocchio/program/src/entrypoint.rs
+++ b/pinocchio/program/src/entrypoint.rs
@@ -274,10 +274,14 @@ pub fn process_instruction(accounts: &[AccountInfo], instruction_data: &[u8]) ->
 /// - `1`: `InitializeAccount`
 /// - `3`: `Transfer`
 /// - `7`: `MintTo`
+/// - `8`: `Burn`
 /// - `9`: `CloseAccount`
-/// - `16`: `InitializeAccount2`
+/// - `12`: `TransferChecked`
+/// - `15`: `BurnChecked`
+/// - `17`: `SyncNative`
 /// - `18`: `InitializeAccount3`
 /// - `20`: `InitializeMint2`
+/// - `22`: `InitializeImmutableOwner`
 #[inline(always)]
 pub(crate) fn inner_process_instruction(
     accounts: &[AccountInfo],


### PR DESCRIPTION
### Problem

The last round of audit suggested to clarify aspects of the implementation:

* `TokenError`: unused error variant
* `TokenInstruction::Batch` and `TokenInstruction::SetAuthority` behaviour
* `inner_process_instruction`: stale comment

### Solution

Add clarifying comments for the above points.