### PR TITLE
program: Add deprecated note

### DIFF
--- a/program/README.md
+++ b/program/README.md
@@ -1,7 +1,10 @@
 > ⚠️ DEPRECATED
 > 
 > This crate has been deprecated and is no longer actively maintained.
-> Please use to [spl-token-interface](https://crates.io/crates/spl-token-interface) instead.
+> 
+> Please use [spl-token-interface](https://crates.io/crates/spl-token-interface) for
+> state and instruction types, and [p-token](https://github.com/solana-program/token/tree/main/pinocchio/program)
+> for the program implementation.
 
 # Token program
 

--- a/program/README.md
+++ b/program/README.md
@@ -1,3 +1,8 @@
+> ⚠️ DEPRECATED
+> 
+> This crate has been deprecated and is no longer actively maintained.
+> Please use to [spl-token-interface](https://crates.io/crates/spl-token-interface) instead.
+
 # Token program
 
 A token program on the Solana blockchain, usable for fungible and non-fungible tokens.

--- a/program/src/lib.rs
+++ b/program/src/lib.rs
@@ -1,7 +1,13 @@
+#![deprecated(since = "9.0.1", note = "Please use `spl-token-interface` instead")]
 #![allow(clippy::arithmetic_side_effects)]
 #![deny(missing_docs)]
 
 //! An ERC20-like Token program for the Solana blockchain
+//!
+//! ⚠️ DEPRECATED
+//!
+//! This crate has been deprecated and is no longer actively maintained.
+//! Please use to [spl-token-interface](https://crates.io/crates/spl-token-interface) instead.
 
 pub mod error;
 pub mod instruction;

--- a/program/src/lib.rs
+++ b/program/src/lib.rs
@@ -1,4 +1,7 @@
-#![deprecated(since = "9.0.1", note = "Please use `spl-token-interface` instead")]
+#![deprecated(
+    since = "9.0.1",
+    note = "Please use `spl-token-interface` for state and instruction types, and p-token for the program implementation"
+)]
 #![allow(clippy::arithmetic_side_effects)]
 #![deny(missing_docs)]
 
@@ -7,7 +10,10 @@
 //! ⚠️ DEPRECATED
 //!
 //! This crate has been deprecated and is no longer actively maintained.
-//! Please use to [spl-token-interface](https://crates.io/crates/spl-token-interface) instead.
+//!
+//! Please use [spl-token-interface](https://crates.io/crates/spl-token-interface) for
+//! state and instruction types, and [p-token](https://github.com/solana-program/token/tree/main/pinocchio/program)
+//! for the program implementation.
 
 pub mod error;
 pub mod instruction;

--- a/program/src/lib.rs
+++ b/program/src/lib.rs
@@ -7,7 +7,7 @@
 
 //! An ERC20-like Token program for the Solana blockchain
 //!
-//! ⚠️ DEPRECATED
+//! `⚠️ DEPRECATED`
 //!
 //! This crate has been deprecated and is no longer actively maintained.
 //!


### PR DESCRIPTION
### Problem

p-token was deployed to mainnet and the original SPL Token implementation won't be used going forwards.

### Solution

Deprecate the spl-token crate and indicate that spl-token-interface should be used instead.