### PR TITLE
Update Codama and regenerate clients

### DIFF
--- a/clients/js/src/generated/errors/associatedToken.ts
+++ b/clients/js/src/generated/errors/associatedToken.ts
@@ -20,14 +20,14 @@ export const ASSOCIATED_TOKEN_ERROR__INVALID_OWNER = 0x0; // 0
 export type AssociatedTokenError = typeof ASSOCIATED_TOKEN_ERROR__INVALID_OWNER;
 
 let associatedTokenErrorMessages: Record<AssociatedTokenError, string> | undefined;
-if (process.env.NODE_ENV !== 'production') {
+if (process.env['NODE_ENV'] !== 'production') {
     associatedTokenErrorMessages = {
         [ASSOCIATED_TOKEN_ERROR__INVALID_OWNER]: `Associated token account owner does not match address derivation`,
     };
 }
 
 export function getAssociatedTokenErrorMessage(code: AssociatedTokenError): string {
-    if (process.env.NODE_ENV !== 'production') {
+    if (process.env['NODE_ENV'] !== 'production') {
         return (associatedTokenErrorMessages as Record<AssociatedTokenError, string>)[code];
     }
 

--- a/clients/js/src/generated/errors/token.ts
+++ b/clients/js/src/generated/errors/token.ts
@@ -78,7 +78,7 @@ export type TokenError =
     | typeof TOKEN_ERROR__UNINITIALIZED_STATE;
 
 let tokenErrorMessages: Record<TokenError, string> | undefined;
-if (process.env.NODE_ENV !== 'production') {
+if (process.env['NODE_ENV'] !== 'production') {
     tokenErrorMessages = {
         [TOKEN_ERROR__ACCOUNT_FROZEN]: `Account is frozen`,
         [TOKEN_ERROR__ALREADY_IN_USE]: `Already in use`,
@@ -104,7 +104,7 @@ if (process.env.NODE_ENV !== 'production') {
 }
 
 export function getTokenErrorMessage(code: TokenError): string {
-    if (process.env.NODE_ENV !== 'production') {
+    if (process.env['NODE_ENV'] !== 'production') {
         return (tokenErrorMessages as Record<TokenError, string>)[code];
     }
 

--- a/clients/js/src/generated/instructions/amountToUiAmount.ts
+++ b/clients/js/src/generated/instructions/amountToUiAmount.ts
@@ -33,7 +33,7 @@ import { TOKEN_PROGRAM_ADDRESS } from '../programs';
 
 export const AMOUNT_TO_UI_AMOUNT_DISCRIMINATOR = 23;
 
-export function getAmountToUiAmountDiscriminatorBytes() {
+export function getAmountToUiAmountDiscriminatorBytes(): ReadonlyUint8Array {
     return getU8Encoder().encode(AMOUNT_TO_UI_AMOUNT_DISCRIMINATOR);
 }
 

--- a/clients/js/src/generated/instructions/approve.ts
+++ b/clients/js/src/generated/instructions/approve.ts
@@ -38,7 +38,7 @@ import { TOKEN_PROGRAM_ADDRESS } from '../programs';
 
 export const APPROVE_DISCRIMINATOR = 4;
 
-export function getApproveDiscriminatorBytes() {
+export function getApproveDiscriminatorBytes(): ReadonlyUint8Array {
     return getU8Encoder().encode(APPROVE_DISCRIMINATOR);
 }
 

--- a/clients/js/src/generated/instructions/approveChecked.ts
+++ b/clients/js/src/generated/instructions/approveChecked.ts
@@ -38,7 +38,7 @@ import { TOKEN_PROGRAM_ADDRESS } from '../programs';
 
 export const APPROVE_CHECKED_DISCRIMINATOR = 13;
 
-export function getApproveCheckedDiscriminatorBytes() {
+export function getApproveCheckedDiscriminatorBytes(): ReadonlyUint8Array {
     return getU8Encoder().encode(APPROVE_CHECKED_DISCRIMINATOR);
 }
 

--- a/clients/js/src/generated/instructions/batch.ts
+++ b/clients/js/src/generated/instructions/batch.ts
@@ -33,7 +33,7 @@ import { TOKEN_PROGRAM_ADDRESS } from '../programs';
 
 export const BATCH_DISCRIMINATOR = 255;
 
-export function getBatchDiscriminatorBytes() {
+export function getBatchDiscriminatorBytes(): ReadonlyUint8Array {
     return getU8Encoder().encode(BATCH_DISCRIMINATOR);
 }
 

--- a/clients/js/src/generated/instructions/burn.ts
+++ b/clients/js/src/generated/instructions/burn.ts
@@ -38,7 +38,7 @@ import { TOKEN_PROGRAM_ADDRESS } from '../programs';
 
 export const BURN_DISCRIMINATOR = 8;
 
-export function getBurnDiscriminatorBytes() {
+export function getBurnDiscriminatorBytes(): ReadonlyUint8Array {
     return getU8Encoder().encode(BURN_DISCRIMINATOR);
 }
 

--- a/clients/js/src/generated/instructions/burnChecked.ts
+++ b/clients/js/src/generated/instructions/burnChecked.ts
@@ -38,7 +38,7 @@ import { TOKEN_PROGRAM_ADDRESS } from '../programs';
 
 export const BURN_CHECKED_DISCRIMINATOR = 15;
 
-export function getBurnCheckedDiscriminatorBytes() {
+export function getBurnCheckedDiscriminatorBytes(): ReadonlyUint8Array {
     return getU8Encoder().encode(BURN_CHECKED_DISCRIMINATOR);
 }
 

--- a/clients/js/src/generated/instructions/closeAccount.ts
+++ b/clients/js/src/generated/instructions/closeAccount.ts
@@ -36,7 +36,7 @@ import { TOKEN_PROGRAM_ADDRESS } from '../programs';
 
 export const CLOSE_ACCOUNT_DISCRIMINATOR = 9;
 
-export function getCloseAccountDiscriminatorBytes() {
+export function getCloseAccountDiscriminatorBytes(): ReadonlyUint8Array {
     return getU8Encoder().encode(CLOSE_ACCOUNT_DISCRIMINATOR);
 }
 

--- a/clients/js/src/generated/instructions/createAssociatedToken.ts
+++ b/clients/js/src/generated/instructions/createAssociatedToken.ts
@@ -40,7 +40,7 @@ import { ASSOCIATED_TOKEN_PROGRAM_ADDRESS } from '../programs';
 
 export const CREATE_ASSOCIATED_TOKEN_DISCRIMINATOR = 0;
 
-export function getCreateAssociatedTokenDiscriminatorBytes() {
+export function getCreateAssociatedTokenDiscriminatorBytes(): ReadonlyUint8Array {
     return getU8Encoder().encode(CREATE_ASSOCIATED_TOKEN_DISCRIMINATOR);
 }
 

--- a/clients/js/src/generated/instructions/createAssociatedTokenIdempotent.ts
+++ b/clients/js/src/generated/instructions/createAssociatedTokenIdempotent.ts
@@ -40,7 +40,7 @@ import { ASSOCIATED_TOKEN_PROGRAM_ADDRESS } from '../programs';
 
 export const CREATE_ASSOCIATED_TOKEN_IDEMPOTENT_DISCRIMINATOR = 1;
 
-export function getCreateAssociatedTokenIdempotentDiscriminatorBytes() {
+export function getCreateAssociatedTokenIdempotentDiscriminatorBytes(): ReadonlyUint8Array {
     return getU8Encoder().encode(CREATE_ASSOCIATED_TOKEN_IDEMPOTENT_DISCRIMINATOR);
 }
 

--- a/clients/js/src/generated/instructions/freezeAccount.ts
+++ b/clients/js/src/generated/instructions/freezeAccount.ts
@@ -36,7 +36,7 @@ import { TOKEN_PROGRAM_ADDRESS } from '../programs';
 
 export const FREEZE_ACCOUNT_DISCRIMINATOR = 10;
 
-export function getFreezeAccountDiscriminatorBytes() {
+export function getFreezeAccountDiscriminatorBytes(): ReadonlyUint8Array {
     return getU8Encoder().encode(FREEZE_ACCOUNT_DISCRIMINATOR);
 }
 

--- a/clients/js/src/generated/instructions/getAccountDataSize.ts
+++ b/clients/js/src/generated/instructions/getAccountDataSize.ts
@@ -31,7 +31,7 @@ import { TOKEN_PROGRAM_ADDRESS } from '../programs';
 
 export const GET_ACCOUNT_DATA_SIZE_DISCRIMINATOR = 21;
 
-export function getGetAccountDataSizeDiscriminatorBytes() {
+export function getGetAccountDataSizeDiscriminatorBytes(): ReadonlyUint8Array {
     return getU8Encoder().encode(GET_ACCOUNT_DATA_SIZE_DISCRIMINATOR);
 }
 

--- a/clients/js/src/generated/instructions/initializeAccount.ts
+++ b/clients/js/src/generated/instructions/initializeAccount.ts
@@ -32,7 +32,7 @@ import { TOKEN_PROGRAM_ADDRESS } from '../programs';
 
 export const INITIALIZE_ACCOUNT_DISCRIMINATOR = 1;
 
-export function getInitializeAccountDiscriminatorBytes() {
+export function getInitializeAccountDiscriminatorBytes(): ReadonlyUint8Array {
     return getU8Encoder().encode(INITIALIZE_ACCOUNT_DISCRIMINATOR);
 }
 

--- a/clients/js/src/generated/instructions/initializeAccount2.ts
+++ b/clients/js/src/generated/instructions/initializeAccount2.ts
@@ -34,7 +34,7 @@ import { TOKEN_PROGRAM_ADDRESS } from '../programs';
 
 export const INITIALIZE_ACCOUNT2_DISCRIMINATOR = 16;
 
-export function getInitializeAccount2DiscriminatorBytes() {
+export function getInitializeAccount2DiscriminatorBytes(): ReadonlyUint8Array {
     return getU8Encoder().encode(INITIALIZE_ACCOUNT2_DISCRIMINATOR);
 }
 

--- a/clients/js/src/generated/instructions/initializeAccount3.ts
+++ b/clients/js/src/generated/instructions/initializeAccount3.ts
@@ -34,7 +34,7 @@ import { TOKEN_PROGRAM_ADDRESS } from '../programs';
 
 export const INITIALIZE_ACCOUNT3_DISCRIMINATOR = 18;
 
-export function getInitializeAccount3DiscriminatorBytes() {
+export function getInitializeAccount3DiscriminatorBytes(): ReadonlyUint8Array {
     return getU8Encoder().encode(INITIALIZE_ACCOUNT3_DISCRIMINATOR);
 }
 

--- a/clients/js/src/generated/instructions/initializeImmutableOwner.ts
+++ b/clients/js/src/generated/instructions/initializeImmutableOwner.ts
@@ -31,7 +31,7 @@ import { TOKEN_PROGRAM_ADDRESS } from '../programs';
 
 export const INITIALIZE_IMMUTABLE_OWNER_DISCRIMINATOR = 22;
 
-export function getInitializeImmutableOwnerDiscriminatorBytes() {
+export function getInitializeImmutableOwnerDiscriminatorBytes(): ReadonlyUint8Array {
     return getU8Encoder().encode(INITIALIZE_IMMUTABLE_OWNER_DISCRIMINATOR);
 }
 

--- a/clients/js/src/generated/instructions/initializeMint.ts
+++ b/clients/js/src/generated/instructions/initializeMint.ts
@@ -39,7 +39,7 @@ import { TOKEN_PROGRAM_ADDRESS } from '../programs';
 
 export const INITIALIZE_MINT_DISCRIMINATOR = 0;
 
-export function getInitializeMintDiscriminatorBytes() {
+export function getInitializeMintDiscriminatorBytes(): ReadonlyUint8Array {
     return getU8Encoder().encode(INITIALIZE_MINT_DISCRIMINATOR);
 }
 

--- a/clients/js/src/generated/instructions/initializeMint2.ts
+++ b/clients/js/src/generated/instructions/initializeMint2.ts
@@ -38,7 +38,7 @@ import { TOKEN_PROGRAM_ADDRESS } from '../programs';
 
 export const INITIALIZE_MINT2_DISCRIMINATOR = 20;
 
-export function getInitializeMint2DiscriminatorBytes() {
+export function getInitializeMint2DiscriminatorBytes(): ReadonlyUint8Array {
     return getU8Encoder().encode(INITIALIZE_MINT2_DISCRIMINATOR);
 }
 

--- a/clients/js/src/generated/instructions/initializeMultisig.ts
+++ b/clients/js/src/generated/instructions/initializeMultisig.ts
@@ -33,7 +33,7 @@ import { TOKEN_PROGRAM_ADDRESS } from '../programs';
 
 export const INITIALIZE_MULTISIG_DISCRIMINATOR = 2;
 
-export function getInitializeMultisigDiscriminatorBytes() {
+export function getInitializeMultisigDiscriminatorBytes(): ReadonlyUint8Array {
     return getU8Encoder().encode(INITIALIZE_MULTISIG_DISCRIMINATOR);
 }
 

--- a/clients/js/src/generated/instructions/initializeMultisig2.ts
+++ b/clients/js/src/generated/instructions/initializeMultisig2.ts
@@ -32,7 +32,7 @@ import { TOKEN_PROGRAM_ADDRESS } from '../programs';
 
 export const INITIALIZE_MULTISIG2_DISCRIMINATOR = 19;
 
-export function getInitializeMultisig2DiscriminatorBytes() {
+export function getInitializeMultisig2DiscriminatorBytes(): ReadonlyUint8Array {
     return getU8Encoder().encode(INITIALIZE_MULTISIG2_DISCRIMINATOR);
 }
 

--- a/clients/js/src/generated/instructions/mintTo.ts
+++ b/clients/js/src/generated/instructions/mintTo.ts
@@ -38,7 +38,7 @@ import { TOKEN_PROGRAM_ADDRESS } from '../programs';
 
 export const MINT_TO_DISCRIMINATOR = 7;
 
-export function getMintToDiscriminatorBytes() {
+export function getMintToDiscriminatorBytes(): ReadonlyUint8Array {
     return getU8Encoder().encode(MINT_TO_DISCRIMINATOR);
 }
 

--- a/clients/js/src/generated/instructions/mintToChecked.ts
+++ b/clients/js/src/generated/instructions/mintToChecked.ts
@@ -38,7 +38,7 @@ import { TOKEN_PROGRAM_ADDRESS } from '../programs';
 
 export const MINT_TO_CHECKED_DISCRIMINATOR = 14;
 
-export function getMintToCheckedDiscriminatorBytes() {
+export function getMintToCheckedDiscriminatorBytes(): ReadonlyUint8Array {
     return getU8Encoder().encode(MINT_TO_CHECKED_DISCRIMINATOR);
 }
 

--- a/clients/js/src/generated/instructions/recoverNestedAssociatedToken.ts
+++ b/clients/js/src/generated/instructions/recoverNestedAssociatedToken.ts
@@ -40,7 +40,7 @@ import { ASSOCIATED_TOKEN_PROGRAM_ADDRESS } from '../programs';
 
 export const RECOVER_NESTED_ASSOCIATED_TOKEN_DISCRIMINATOR = 2;
 
-export function getRecoverNestedAssociatedTokenDiscriminatorBytes() {
+export function getRecoverNestedAssociatedTokenDiscriminatorBytes(): ReadonlyUint8Array {
     return getU8Encoder().encode(RECOVER_NESTED_ASSOCIATED_TOKEN_DISCRIMINATOR);
 }
 

--- a/clients/js/src/generated/instructions/revoke.ts
+++ b/clients/js/src/generated/instructions/revoke.ts
@@ -36,7 +36,7 @@ import { TOKEN_PROGRAM_ADDRESS } from '../programs';
 
 export const REVOKE_DISCRIMINATOR = 5;
 
-export function getRevokeDiscriminatorBytes() {
+export function getRevokeDiscriminatorBytes(): ReadonlyUint8Array {
     return getU8Encoder().encode(REVOKE_DISCRIMINATOR);
 }
 

--- a/clients/js/src/generated/instructions/setAuthority.ts
+++ b/clients/js/src/generated/instructions/setAuthority.ts
@@ -43,7 +43,7 @@ import { getAuthorityTypeDecoder, getAuthorityTypeEncoder, type AuthorityType, t
 
 export const SET_AUTHORITY_DISCRIMINATOR = 6;
 
-export function getSetAuthorityDiscriminatorBytes() {
+export function getSetAuthorityDiscriminatorBytes(): ReadonlyUint8Array {
     return getU8Encoder().encode(SET_AUTHORITY_DISCRIMINATOR);
 }
 

--- a/clients/js/src/generated/instructions/syncNative.ts
+++ b/clients/js/src/generated/instructions/syncNative.ts
@@ -32,7 +32,7 @@ import { TOKEN_PROGRAM_ADDRESS } from '../programs';
 
 export const SYNC_NATIVE_DISCRIMINATOR = 17;
 
-export function getSyncNativeDiscriminatorBytes() {
+export function getSyncNativeDiscriminatorBytes(): ReadonlyUint8Array {
     return getU8Encoder().encode(SYNC_NATIVE_DISCRIMINATOR);
 }
 

--- a/clients/js/src/generated/instructions/thawAccount.ts
+++ b/clients/js/src/generated/instructions/thawAccount.ts
@@ -36,7 +36,7 @@ import { TOKEN_PROGRAM_ADDRESS } from '../programs';
 
 export const THAW_ACCOUNT_DISCRIMINATOR = 11;
 
-export function getThawAccountDiscriminatorBytes() {
+export function getThawAccountDiscriminatorBytes(): ReadonlyUint8Array {
     return getU8Encoder().encode(THAW_ACCOUNT_DISCRIMINATOR);
 }
 

--- a/clients/js/src/generated/instructions/transfer.ts
+++ b/clients/js/src/generated/instructions/transfer.ts
@@ -38,7 +38,7 @@ import { TOKEN_PROGRAM_ADDRESS } from '../programs';
 
 export const TRANSFER_DISCRIMINATOR = 3;
 
-export function getTransferDiscriminatorBytes() {
+export function getTransferDiscriminatorBytes(): ReadonlyUint8Array {
     return getU8Encoder().encode(TRANSFER_DISCRIMINATOR);
 }
 

--- a/clients/js/src/generated/instructions/transferChecked.ts
+++ b/clients/js/src/generated/instructions/transferChecked.ts
@@ -38,7 +38,7 @@ import { TOKEN_PROGRAM_ADDRESS } from '../programs';
 
 export const TRANSFER_CHECKED_DISCRIMINATOR = 12;
 
-export function getTransferCheckedDiscriminatorBytes() {
+export function getTransferCheckedDiscriminatorBytes(): ReadonlyUint8Array {
     return getU8Encoder().encode(TRANSFER_CHECKED_DISCRIMINATOR);
 }
 

--- a/clients/js/src/generated/instructions/uiAmountToAmount.ts
+++ b/clients/js/src/generated/instructions/uiAmountToAmount.ts
@@ -33,7 +33,7 @@ import { TOKEN_PROGRAM_ADDRESS } from '../programs';
 
 export const UI_AMOUNT_TO_AMOUNT_DISCRIMINATOR = 24;
 
-export function getUiAmountToAmountDiscriminatorBytes() {
+export function getUiAmountToAmountDiscriminatorBytes(): ReadonlyUint8Array {
     return getU8Encoder().encode(UI_AMOUNT_TO_AMOUNT_DISCRIMINATOR);
 }
 

--- a/clients/js/src/generated/instructions/unwrapLamports.ts
+++ b/clients/js/src/generated/instructions/unwrapLamports.ts
@@ -43,7 +43,7 @@ import { TOKEN_PROGRAM_ADDRESS } from '../programs';
 
 export const UNWRAP_LAMPORTS_DISCRIMINATOR = 45;
 
-export function getUnwrapLamportsDiscriminatorBytes() {
+export function getUnwrapLamportsDiscriminatorBytes(): ReadonlyUint8Array {
     return getU8Encoder().encode(UNWRAP_LAMPORTS_DISCRIMINATOR);
 }
 

--- a/clients/js/src/generated/instructions/withdrawExcessLamports.ts
+++ b/clients/js/src/generated/instructions/withdrawExcessLamports.ts
@@ -36,7 +36,7 @@ import { TOKEN_PROGRAM_ADDRESS } from '../programs';
 
 export const WITHDRAW_EXCESS_LAMPORTS_DISCRIMINATOR = 38;
 
-export function getWithdrawExcessLamportsDiscriminatorBytes() {
+export function getWithdrawExcessLamportsDiscriminatorBytes(): ReadonlyUint8Array {
     return getU8Encoder().encode(WITHDRAW_EXCESS_LAMPORTS_DISCRIMINATOR);
 }
 

--- a/clients/js/src/generated/programs/associatedToken.ts
+++ b/clients/js/src/generated/programs/associatedToken.ts
@@ -9,6 +9,7 @@
 import {
     assertIsInstructionWithAccounts,
     containsBytes,
+    extendClient,
     getU8Encoder,
     SOLANA_ERROR__PROGRAM_CLIENTS__FAILED_TO_IDENTIFY_INSTRUCTION,
     SOLANA_ERROR__PROGRAM_CLIENTS__UNRECOGNIZED_INSTRUCTION_TYPE,
@@ -36,6 +37,7 @@ import {
     type ParsedRecoverNestedAssociatedTokenInstruction,
     type RecoverNestedAssociatedTokenAsyncInput,
 } from '../instructions';
+import { findAssociatedTokenPda } from '../pdas';
 
 export const ASSOCIATED_TOKEN_PROGRAM_ADDRESS =
     'ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL' as Address<'ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL'>;
@@ -110,7 +112,10 @@ export function parseAssociatedTokenInstruction<TProgram extends string>(
     }
 }
 
-export type AssociatedTokenPlugin = { instructions: AssociatedTokenPluginInstructions };
+export type AssociatedTokenPlugin = {
+    instructions: AssociatedTokenPluginInstructions;
+    pdas: AssociatedTokenPluginPdas;
+};
 
 export type AssociatedTokenPluginInstructions = {
     createAssociatedToken: (
@@ -124,14 +129,17 @@ export type AssociatedTokenPluginInstructions = {
     ) => ReturnType<typeof getRecoverNestedAssociatedTokenInstructionAsync> & SelfPlanAndSendFunctions;
 };
 
+export type AssociatedTokenPluginPdas = { associatedToken: typeof findAssociatedTokenPda };
+
 export type AssociatedTokenPluginRequirements = ClientWithPayer &
     ClientWithTransactionPlanning &
     ClientWithTransactionSending;
 
 export function associatedTokenProgram() {
-    return <T extends AssociatedTokenPluginRequirements>(client: T) => {
-        return {
-            ...client,
+    return <T extends AssociatedTokenPluginRequirements>(
+        client: T,
+    ): Omit<T, 'associatedToken'> & { associatedToken: AssociatedTokenPlugin } => {
+        return extendClient(client, {
             associatedToken: <AssociatedTokenPlugin>{
                 instructions: {
                     createAssociatedToken: input =>
@@ -150,8 +158,9 @@ export function associatedTokenProgram() {
                     recoverNestedAssociatedToken: input =>
                         addSelfPlanAndSendFunctions(client, getRecoverNestedAssociatedTokenInstructionAsync(input)),
                 },
+                pdas: { associatedToken: findAssociatedTokenPda },
             },
-        };
+        });
     };
 }
 

--- a/clients/js/src/generated/programs/token.ts
+++ b/clients/js/src/generated/programs/token.ts
@@ -9,6 +9,7 @@
 import {
     assertIsInstructionWithAccounts,
     containsBytes,
+    extendClient,
     getU8Encoder,
     SOLANA_ERROR__PROGRAM_CLIENTS__FAILED_TO_IDENTIFY_ACCOUNT,
     SOLANA_ERROR__PROGRAM_CLIENTS__FAILED_TO_IDENTIFY_INSTRUCTION,
@@ -581,9 +582,8 @@ export type TokenPluginRequirements = ClientWithRpc<GetAccountInfoApi & GetMulti
     ClientWithTransactionSending;
 
 export function tokenProgram() {
-    return <T extends TokenPluginRequirements>(client: T) => {
-        return {
-            ...client,
+    return <T extends TokenPluginRequirements>(client: T): Omit<T, 'token'> & { token: TokenPlugin } => {
+        return extendClient(client, {
             token: <TokenPlugin>{
                 accounts: {
                     mint: addSelfFetchFunctions(client, getMintCodec()),
@@ -631,6 +631,6 @@ export function tokenProgram() {
                     batch: input => addSelfPlanAndSendFunctions(client, getBatchInstruction(input)),
                 },
             },
-        };
+        });
     };
 }

--- a/codama.json
+++ b/codama.json
@@ -4,7 +4,7 @@
     "scripts": {
         "js": {
             "from": "@codama/renderers-js",
-            "args": ["clients/js", { "kitImportStrategy": "rootOnly" }]
+            "args": ["clients/js", { "kitImportStrategy": "rootOnly", "syncPackageJson": true }]
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
     "private": true,
     "devDependencies": {
-        "@codama/renderers-js": "^2.0.2",
+        "@codama/renderers-js": "^2.2.0",
         "@solana/prettier-config-solana": "0.0.6",
-        "codama": "^1.5.0"
+        "codama": "^1.6.0"
     },
     "engines": {
         "node": ">=v20.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,83 +9,86 @@ importers:
   .:
     devDependencies:
       '@codama/renderers-js':
-        specifier: ^2.0.2
-        version: 2.0.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+        specifier: ^2.2.0
+        version: 2.2.0
       '@solana/prettier-config-solana':
         specifier: 0.0.6
-        version: 0.0.6(prettier@3.8.1)
+        version: 0.0.6(prettier@3.8.3)
       codama:
-        specifier: ^1.5.0
-        version: 1.5.0
+        specifier: ^1.6.0
+        version: 1.7.0
 
 packages:
 
-  '@codama/cli@1.4.4':
-    resolution: {integrity: sha512-0uLecW/RZC2c1wx3j/eiRAYvilvNY+2DoyEYu/hV0OfM1/uIgIyuy5U+wolV+LY4wLFYdApjYdy+5D32lngCHg==}
+  '@codama/cli@1.5.2':
+    resolution: {integrity: sha512-d5b6+m0TFYsIii4ALPIWrC6vGNbTLCXOaBqZO5WdI522w4jlk2MQozuSDVhAMBWQjxt9QD/WOJer8PHYwa1rYA==}
     hasBin: true
 
-  '@codama/errors@1.5.0':
-    resolution: {integrity: sha512-i4cS+S7JaZXhofQHFY3cwzt8rqxUVPNaeJND5VOyKUbtcOi933YXJXk52gDG4mc+CpGqHJijsJjfSpr1lJGxzg==}
+  '@codama/errors@1.7.0':
+    resolution: {integrity: sha512-N1E4LT3XRYqHHJAnL+eVQ5V3Pc0uSPjsn4Xt6QEO6Fz1p0slF6hbD+/axkFUc7+lNCAfgnkKzhk+6SpFLU/WrQ==}
     hasBin: true
 
-  '@codama/node-types@1.5.0':
-    resolution: {integrity: sha512-Ebz2vOUukmNaFXWdkni1ZihXkAIUnPYtqIMXYxKXOxjMP+TGz2q0lGtRo7sqw1pc2ksFBIkfBp5pZsl5p6gwXA==}
+  '@codama/fragments@0.1.0':
+    resolution: {integrity: sha512-rWnSKw4UA9LS7mMQyzKnR1woibVEYrYgp66+i+JB+O1lnvU/i/KCH4TmoV+S6Y3ADL2WyznrwfDA3rBET6U5Cg==}
 
-  '@codama/nodes@1.5.0':
-    resolution: {integrity: sha512-yg+xmorWiMNjS3n19CGIt/FZ/ZCuDIu+HEY45bq6gHu1MN3RtJZY+Q3v0ErnBPA60D8mNWkvkKoeSZXfzcAvfw==}
+  '@codama/node-types@1.7.0':
+    resolution: {integrity: sha512-VDytcSgN6jOGEh4aJ1LgSnqCe1drSEUSdAeKOV92aU0MOYiDi2s2B18+Gx7dx40mex2GfVc3zamu7KGzTlxegA==}
 
-  '@codama/renderers-core@1.3.5':
-    resolution: {integrity: sha512-MuZLU+3LZPQb1HuZffwZl+v5JHQDe5LYHGhA1wTMNlwRedYIysSxBjogHNciNIHsKP3JjmqyYmLO5LCEp3hjaQ==}
+  '@codama/nodes@1.7.0':
+    resolution: {integrity: sha512-PZ1zI+SbE1PEaGEka0KjdFrAJ7e9O0kPG4CCGYhjsqUo76OBbINRjNVx7pkP4r8Ksa2r/BLbVIfZV1M/n5J5Kg==}
 
-  '@codama/renderers-js@2.0.2':
-    resolution: {integrity: sha512-5gEDCgfqqUnc/uTAphj06+tU6n2fVZH439ih7H1yAF8WM+ftHB7Ph0rMb63J7/d+HRRZhdEet0Cngs1CZI6GHA==}
+  '@codama/renderers-core@1.3.8':
+    resolution: {integrity: sha512-xy9Qb5BLYTi1OyvlRhRD7n0HUevOQ3QcHSPq9N3kqoUOgL2ziXPXvoejzzLC0OkvA16M7WvK3ihNx/nf4UEClQ==}
+
+  '@codama/renderers-js@2.2.0':
+    resolution: {integrity: sha512-/GWVnB329kMkeqlOqX+NWQAmd1k6yybVOp7C5X+LEvrZ2A5w1saQwWFbBMCq/EQPqnFU+CRFoG/+7KubAEa73Q==}
     engines: {node: '>=20.18.0'}
 
-  '@codama/validators@1.5.0':
-    resolution: {integrity: sha512-p3ufDxnCH1jiuHGzcBv4/d+ctzUcKD2K3gX/W8169tC41o9DggjlEpNy1Z6YAAhVb3wHnmXVGA2qmp32rWSfWw==}
+  '@codama/validators@1.7.0':
+    resolution: {integrity: sha512-PBWN4zLikf6sssZD6sDVN7ASbh++fzvZ5pluHu6VlSQDk7lFL3Gsh7P1Q5JgIuXkM2gFntzCrTJSStToDCAW3g==}
 
-  '@codama/visitors-core@1.5.0':
-    resolution: {integrity: sha512-3PIAlBX0a06hIxzyPtQMfQcqWGFBgfbwysSwcXBbvHUYbemwhD6xwlBKJuqTwm9DyFj3faStp5fpvcp03Rjxtw==}
+  '@codama/visitors-core@1.7.0':
+    resolution: {integrity: sha512-ii1Z39ORzssMQdpxqpjaHCLbFwO4KZbI1SrsJ1e0r+0g03gxuYEA1H6RoxcrIOuUeOnqNtLb96cErrzHdrx23Q==}
 
-  '@codama/visitors@1.5.0':
-    resolution: {integrity: sha512-SwtQaleXxAaFz6uHygxki621q4nPUDQlnwEhsg+QKOjHpKWXjLYdJof+R8gUiTV/n7/IeNnjvxJTTNfUsvETPQ==}
+  '@codama/visitors@1.7.0':
+    resolution: {integrity: sha512-wk8ufgX3AfKOnaok5H4y1UteLyY/WkDIhhKRE7y5MJqOn5JnxLgL9R4MU2+5TmZUF04sdwyUn6fPho0IqTq+BQ==}
 
-  '@solana/codecs-core@6.0.1':
-    resolution: {integrity: sha512-OnUQk94qfvfE0nVveZ638aNUL3tyRJoorUFiAG0ICTGUo3c6fkYb8vH23o/5O2qmuSmYND1sn+UCaldNMVkFpg==}
+  '@solana/codecs-core@6.9.0':
+    resolution: {integrity: sha512-F2BmLecG/1nTtnjyD509NsEc254pxJKa2bpvotymv1lL1WfEn3zchcZ9SMIiLyL4G6J8b9F3OKIq2YSZho2AOQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: ^5.0.0
+      typescript: '>=5.4.0'
     peerDependenciesMeta:
       typescript:
         optional: true
 
-  '@solana/codecs-numbers@6.0.1':
-    resolution: {integrity: sha512-ZrI1NjUsf4I+Klue/2rlQbZLcGRom/G2E4VB/8x4IEHGOeFLQhXcxmnib8kdgomQRYOzF1BjVDmCYxvZr+6AWA==}
+  '@solana/codecs-numbers@6.9.0':
+    resolution: {integrity: sha512-XMI0FOHV2h7yPAllxWCX8z+J1msidNjXzN1mRjH5KR6C+vfzyKa2xWHve0bNSV/bjVAhqqhc7dQCpBKuF4+ScQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: ^5.0.0
+      typescript: '>=5.4.0'
     peerDependenciesMeta:
       typescript:
         optional: true
 
-  '@solana/codecs-strings@6.0.1':
-    resolution: {integrity: sha512-OmMIfMFbbJVIxveBeATKCj9DsmZ8l4vJPnOLHUop0hLWRiYHTQ1qokMqfk/X8PCmUjXmbXnlp63BikGtdKN3/g==}
+  '@solana/codecs-strings@6.9.0':
+    resolution: {integrity: sha512-PTqYQxMsmdfEEq29bV1AnALD4FjFEsSxOj1fYNqooOSTEQEpUoYEQtsd55/kBsnIKltXbvYwXYXBusm19n1sQA==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       fastestsmallesttextencoderdecoder: ^1.0.22
-      typescript: ^5.0.0
+      typescript: '>=5.4.0'
     peerDependenciesMeta:
       fastestsmallesttextencoderdecoder:
         optional: true
       typescript:
         optional: true
 
-  '@solana/errors@6.0.1':
-    resolution: {integrity: sha512-sMe5GCsXto8F1KDeq9GbZR0+m841SqEYep3NAcYlC0lqF2RG4giaaPQHgrWI5DJR/L7yc8FzUIQfTxnaN7bwOQ==}
+  '@solana/errors@6.9.0':
+    resolution: {integrity: sha512-7i+b07KMnkbHvFlz7uWade3jvyc22UmVm8o9taxPK8YV3JNM/NkS8oQFvMac2MIaLPAlEs7I8MHyVLUal1yY4g==}
     engines: {node: '>=20.18.0'}
     hasBin: true
     peerDependencies:
-      typescript: ^5.0.0
+      typescript: '>=5.4.0'
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -99,8 +102,8 @@ packages:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
 
-  call-bind@1.0.8:
-    resolution: {integrity: sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==}
+  call-bind@1.0.9:
+    resolution: {integrity: sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==}
     engines: {node: '>= 0.4'}
 
   call-bound@1.0.4:
@@ -111,8 +114,8 @@ packages:
     resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
 
-  codama@1.5.0:
-    resolution: {integrity: sha512-hhfSzrOiDX3bV7QmJneEBsBk3ln4gIcMJs6P8BlEJ3EFI+P0QZaTT5W61o8Tq0/79hTZeyj0gP65HZ/LYJil+w==}
+  codama@1.7.0:
+    resolution: {integrity: sha512-kPB7IPAJkPAllxHiPtNDv6+qhTvfRpetYJgxp1iVa4L+BxztmSXTKMZ3Bsjve4ArENvxuUY4GIAchOYqb3G6nw==}
     hasBin: true
 
   commander@14.0.3:
@@ -135,12 +138,9 @@ packages:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
 
-  es-object-atoms@1.1.1:
-    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+  es-object-atoms@1.1.2:
+    resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
     engines: {node: '>= 0.4'}
-
-  fastestsmallesttextencoderdecoder@1.0.22:
-    resolution: {integrity: sha512-Pb8d48e+oIuY4MaM64Cd7OW1gt4nxCHs7/ddPPZ/Ic3sg8yVGM7O9wDvZ7us6ScaUupzM+pfBolwtYhN1IxBIw==}
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
@@ -164,8 +164,8 @@ packages:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
     engines: {node: '>= 0.4'}
 
-  hasown@2.0.2:
-    resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
+  hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
   isarray@2.0.5:
@@ -193,8 +193,8 @@ packages:
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
-  prettier@3.8.1:
-    resolution: {integrity: sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==}
+  prettier@3.8.3:
+    resolution: {integrity: sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==}
     engines: {node: '>=14'}
     hasBin: true
 
@@ -202,8 +202,8 @@ packages:
     resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
     engines: {node: '>= 6'}
 
-  semver@7.7.4:
-    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
+  semver@7.8.1:
+    resolution: {integrity: sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -214,111 +214,102 @@ packages:
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
-  typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
-    engines: {node: '>=14.17'}
-    hasBin: true
-
 snapshots:
 
-  '@codama/cli@1.4.4':
+  '@codama/cli@1.5.2':
     dependencies:
-      '@codama/nodes': 1.5.0
-      '@codama/visitors': 1.5.0
-      '@codama/visitors-core': 1.5.0
+      '@codama/nodes': 1.7.0
+      '@codama/visitors': 1.7.0
+      '@codama/visitors-core': 1.7.0
       commander: 14.0.3
       picocolors: 1.1.1
       prompts: 2.4.2
 
-  '@codama/errors@1.5.0':
+  '@codama/errors@1.7.0':
     dependencies:
-      '@codama/node-types': 1.5.0
+      '@codama/node-types': 1.7.0
       commander: 14.0.3
       picocolors: 1.1.1
 
-  '@codama/node-types@1.5.0': {}
-
-  '@codama/nodes@1.5.0':
+  '@codama/fragments@0.1.0':
     dependencies:
-      '@codama/errors': 1.5.0
-      '@codama/node-types': 1.5.0
+      '@codama/errors': 1.7.0
 
-  '@codama/renderers-core@1.3.5':
-    dependencies:
-      '@codama/errors': 1.5.0
-      '@codama/nodes': 1.5.0
-      '@codama/visitors-core': 1.5.0
+  '@codama/node-types@1.7.0': {}
 
-  '@codama/renderers-js@2.0.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+  '@codama/nodes@1.7.0':
     dependencies:
-      '@codama/errors': 1.5.0
-      '@codama/nodes': 1.5.0
-      '@codama/renderers-core': 1.3.5
-      '@codama/visitors-core': 1.5.0
-      '@solana/codecs-strings': 6.0.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      prettier: 3.8.1
-      semver: 7.7.4
+      '@codama/errors': 1.7.0
+      '@codama/node-types': 1.7.0
+
+  '@codama/renderers-core@1.3.8':
+    dependencies:
+      '@codama/errors': 1.7.0
+      '@codama/fragments': 0.1.0
+      '@codama/nodes': 1.7.0
+      '@codama/visitors-core': 1.7.0
+
+  '@codama/renderers-js@2.2.0':
+    dependencies:
+      '@codama/errors': 1.7.0
+      '@codama/nodes': 1.7.0
+      '@codama/renderers-core': 1.3.8
+      '@codama/visitors-core': 1.7.0
+      '@solana/codecs-strings': 6.9.0
+      prettier: 3.8.3
+      semver: 7.8.1
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
       - typescript
 
-  '@codama/validators@1.5.0':
+  '@codama/validators@1.7.0':
     dependencies:
-      '@codama/errors': 1.5.0
-      '@codama/nodes': 1.5.0
-      '@codama/visitors-core': 1.5.0
+      '@codama/errors': 1.7.0
+      '@codama/nodes': 1.7.0
+      '@codama/visitors-core': 1.7.0
 
-  '@codama/visitors-core@1.5.0':
+  '@codama/visitors-core@1.7.0':
     dependencies:
-      '@codama/errors': 1.5.0
-      '@codama/nodes': 1.5.0
+      '@codama/errors': 1.7.0
+      '@codama/nodes': 1.7.0
       json-stable-stringify: 1.3.0
 
-  '@codama/visitors@1.5.0':
+  '@codama/visitors@1.7.0':
     dependencies:
-      '@codama/errors': 1.5.0
-      '@codama/nodes': 1.5.0
-      '@codama/visitors-core': 1.5.0
+      '@codama/errors': 1.7.0
+      '@codama/nodes': 1.7.0
+      '@codama/visitors-core': 1.7.0
 
-  '@solana/codecs-core@6.0.1(typescript@5.9.3)':
+  '@solana/codecs-core@6.9.0':
     dependencies:
-      '@solana/errors': 6.0.1(typescript@5.9.3)
-    optionalDependencies:
-      typescript: 5.9.3
+      '@solana/errors': 6.9.0
 
-  '@solana/codecs-numbers@6.0.1(typescript@5.9.3)':
+  '@solana/codecs-numbers@6.9.0':
     dependencies:
-      '@solana/codecs-core': 6.0.1(typescript@5.9.3)
-      '@solana/errors': 6.0.1(typescript@5.9.3)
-    optionalDependencies:
-      typescript: 5.9.3
+      '@solana/codecs-core': 6.9.0
+      '@solana/errors': 6.9.0
 
-  '@solana/codecs-strings@6.0.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+  '@solana/codecs-strings@6.9.0':
     dependencies:
-      '@solana/codecs-core': 6.0.1(typescript@5.9.3)
-      '@solana/codecs-numbers': 6.0.1(typescript@5.9.3)
-      '@solana/errors': 6.0.1(typescript@5.9.3)
-    optionalDependencies:
-      fastestsmallesttextencoderdecoder: 1.0.22
-      typescript: 5.9.3
+      '@solana/codecs-core': 6.9.0
+      '@solana/codecs-numbers': 6.9.0
+      '@solana/errors': 6.9.0
 
-  '@solana/errors@6.0.1(typescript@5.9.3)':
+  '@solana/errors@6.9.0':
     dependencies:
       chalk: 5.6.2
       commander: 14.0.3
-    optionalDependencies:
-      typescript: 5.9.3
 
-  '@solana/prettier-config-solana@0.0.6(prettier@3.8.1)':
+  '@solana/prettier-config-solana@0.0.6(prettier@3.8.3)':
     dependencies:
-      prettier: 3.8.1
+      prettier: 3.8.3
 
   call-bind-apply-helpers@1.0.2:
     dependencies:
       es-errors: 1.3.0
       function-bind: 1.1.2
 
-  call-bind@1.0.8:
+  call-bind@1.0.9:
     dependencies:
       call-bind-apply-helpers: 1.0.2
       es-define-property: 1.0.1
@@ -332,13 +323,13 @@ snapshots:
 
   chalk@5.6.2: {}
 
-  codama@1.5.0:
+  codama@1.7.0:
     dependencies:
-      '@codama/cli': 1.4.4
-      '@codama/errors': 1.5.0
-      '@codama/nodes': 1.5.0
-      '@codama/validators': 1.5.0
-      '@codama/visitors': 1.5.0
+      '@codama/cli': 1.5.2
+      '@codama/errors': 1.7.0
+      '@codama/nodes': 1.7.0
+      '@codama/validators': 1.7.0
+      '@codama/visitors': 1.7.0
 
   commander@14.0.3: {}
 
@@ -358,12 +349,9 @@ snapshots:
 
   es-errors@1.3.0: {}
 
-  es-object-atoms@1.1.1:
+  es-object-atoms@1.1.2:
     dependencies:
       es-errors: 1.3.0
-
-  fastestsmallesttextencoderdecoder@1.0.22:
-    optional: true
 
   function-bind@1.1.2: {}
 
@@ -372,18 +360,18 @@ snapshots:
       call-bind-apply-helpers: 1.0.2
       es-define-property: 1.0.1
       es-errors: 1.3.0
-      es-object-atoms: 1.1.1
+      es-object-atoms: 1.1.2
       function-bind: 1.1.2
       get-proto: 1.0.1
       gopd: 1.2.0
       has-symbols: 1.1.0
-      hasown: 2.0.2
+      hasown: 2.0.4
       math-intrinsics: 1.1.0
 
   get-proto@1.0.1:
     dependencies:
       dunder-proto: 1.0.1
-      es-object-atoms: 1.1.1
+      es-object-atoms: 1.1.2
 
   gopd@1.2.0: {}
 
@@ -393,7 +381,7 @@ snapshots:
 
   has-symbols@1.1.0: {}
 
-  hasown@2.0.2:
+  hasown@2.0.4:
     dependencies:
       function-bind: 1.1.2
 
@@ -401,7 +389,7 @@ snapshots:
 
   json-stable-stringify@1.3.0:
     dependencies:
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       call-bound: 1.0.4
       isarray: 2.0.5
       jsonify: 0.0.1
@@ -417,14 +405,14 @@ snapshots:
 
   picocolors@1.1.1: {}
 
-  prettier@3.8.1: {}
+  prettier@3.8.3: {}
 
   prompts@2.4.2:
     dependencies:
       kleur: 3.0.3
       sisteransi: 1.0.5
 
-  semver@7.7.4: {}
+  semver@7.8.1: {}
 
   set-function-length@1.2.2:
     dependencies:
@@ -436,6 +424,3 @@ snapshots:
       has-property-descriptors: 1.0.2
 
   sisteransi@1.0.5: {}
-
-  typescript@5.9.3:
-    optional: true


### PR DESCRIPTION
This PR bumps Codama and its JS renderer to the latest versions (`codama` 1.6, `@codama/renderers-js` 2.2) and regenerates the JavaScript client, reconciling the generated output and configuration accordingly. Only the JavaScript client is regenerated; the hand-written Rust client is unaffected.