### PR TITLE
p-token: Fix relative license link in README

### DIFF
--- a/pinocchio/program/README.md
+++ b/pinocchio/program/README.md
@@ -14,7 +14,7 @@ A `pinocchio`-based Token program.
 
 ## License
 
-The code is licensed under the [Apache License Version 2.0](LICENSE)
+The code is licensed under the [Apache License Version 2.0](../../LICENSE)
 
 ## Regression program
 


### PR DESCRIPTION
`pinocchio/program/README.md` links to the license with a path relative to its own directory:

```
[Apache License Version 2.0](LICENSE)
```

That resolves to `pinocchio/program/LICENSE`, which does not exist. The repository keeps a single license file at the root, so the link currently 404s on GitHub. `../../LICENSE` points at the real file.

This is the only README in the repo that carries a license link, so nothing else needs the same change.
