### PR TITLE
Fix incorrect instruction name in doc comment

### DIFF
--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -832,7 +832,7 @@ impl Processor {
         Ok(())
     }
 
-    /// Processes an [`AmountToUiAmount`](enum.TokenInstruction.html)
+    /// Processes an [`UiAmountToAmount`](enum.TokenInstruction.html)
     /// instruction
     pub fn process_ui_amount_to_amount(
         program_id: &Pubkey,


### PR DESCRIPTION
The doc comment on `process_ui_amount_to_amount` names `AmountToUiAmount`, but this function processes `UiAmountToAmount` (it takes a `ui_amount: &str`). It looks like a copy of the doc from the adjacent `process_amount_to_ui_amount`, whose comment is identical. No code change.
