### PR TITLE
Add clear signing display metadata to the IDL

### DIFF
--- a/idl.json
+++ b/idl.json
@@ -266,6 +266,11 @@
     "instructions": [
       {
         "kind": "instructionNode",
+        "display": {
+          "kind": "instructionDisplayNode",
+          "intent": "Initialize mint",
+          "interpolatedIntent": "Initialize mint ${accounts.mint} with ${data.decimals} decimals"
+        },
         "accounts": [
           {
             "kind": "instructionAccountNode",
@@ -277,6 +282,10 @@
           },
           {
             "kind": "instructionAccountNode",
+            "display": {
+              "kind": "instructionAccountDisplayNode",
+              "skip": "always"
+            },
             "name": "rent",
             "isWritable": false,
             "isSigner": false,
@@ -291,6 +300,10 @@
         "arguments": [
           {
             "kind": "instructionArgumentNode",
+            "display": {
+              "kind": "structFieldDisplayNode",
+              "skip": "always"
+            },
             "name": "discriminator",
             "type": {
               "kind": "numberTypeNode",
@@ -357,9 +370,18 @@
       },
       {
         "kind": "instructionNode",
+        "display": {
+          "kind": "instructionDisplayNode",
+          "intent": "Initialize token account",
+          "interpolatedIntent": "Initialize token account ${accounts.account} for mint ${accounts.mint}"
+        },
         "accounts": [
           {
             "kind": "instructionAccountNode",
+            "display": {
+              "kind": "instructionAccountDisplayNode",
+              "label": "Token Account"
+            },
             "name": "account",
             "isWritable": true,
             "isSigner": false,
@@ -384,6 +406,10 @@
           },
           {
             "kind": "instructionAccountNode",
+            "display": {
+              "kind": "instructionAccountDisplayNode",
+              "skip": "always"
+            },
             "name": "rent",
             "isWritable": false,
             "isSigner": false,
@@ -398,6 +424,10 @@
         "arguments": [
           {
             "kind": "instructionArgumentNode",
+            "display": {
+              "kind": "structFieldDisplayNode",
+              "skip": "always"
+            },
             "name": "discriminator",
             "type": {
               "kind": "numberTypeNode",
@@ -433,6 +463,11 @@
       },
       {
         "kind": "instructionNode",
+        "display": {
+          "kind": "instructionDisplayNode",
+          "intent": "Initialize multisig",
+          "interpolatedIntent": "Initialize multisig ${accounts.multisig} requiring ${data.m} signatures"
+        },
         "accounts": [
           {
             "kind": "instructionAccountNode",
@@ -444,6 +479,10 @@
           },
           {
             "kind": "instructionAccountNode",
+            "display": {
+              "kind": "instructionAccountDisplayNode",
+              "skip": "always"
+            },
             "name": "rent",
             "isWritable": false,
             "isSigner": false,
@@ -458,6 +497,10 @@
         "arguments": [
           {
             "kind": "instructionArgumentNode",
+            "display": {
+              "kind": "structFieldDisplayNode",
+              "skip": "always"
+            },
             "name": "discriminator",
             "type": {
               "kind": "numberTypeNode",
@@ -470,6 +513,10 @@
           },
           {
             "kind": "instructionArgumentNode",
+            "display": {
+              "kind": "structFieldDisplayNode",
+              "label": "Required Signatures"
+            },
             "name": "m",
             "type": {
               "kind": "numberTypeNode",
@@ -491,6 +538,10 @@
         "remainingAccounts": [
           {
             "kind": "instructionRemainingAccountsNode",
+            "display": {
+              "kind": "instructionAccountDisplayNode",
+              "label": "Signers"
+            },
             "value": {
               "kind": "argumentValueNode",
               "name": "signers"
@@ -515,9 +566,18 @@
       },
       {
         "kind": "instructionNode",
+        "display": {
+          "kind": "instructionDisplayNode",
+          "intent": "Transfer tokens",
+          "interpolatedIntent": "Transfer ${data.amount} from ${accounts.source} to ${accounts.destination}"
+        },
         "accounts": [
           {
             "kind": "instructionAccountNode",
+            "display": {
+              "kind": "instructionAccountDisplayNode",
+              "label": "From"
+            },
             "name": "source",
             "isWritable": true,
             "isSigner": false,
@@ -526,6 +586,10 @@
           },
           {
             "kind": "instructionAccountNode",
+            "display": {
+              "kind": "instructionAccountDisplayNode",
+              "label": "To"
+            },
             "name": "destination",
             "isWritable": true,
             "isSigner": false,
@@ -547,6 +611,10 @@
         "arguments": [
           {
             "kind": "instructionArgumentNode",
+            "display": {
+              "kind": "structFieldDisplayNode",
+              "skip": "always"
+            },
             "name": "discriminator",
             "type": {
               "kind": "numberTypeNode",
@@ -562,6 +630,13 @@
             "name": "amount",
             "type": {
               "kind": "numberTypeNode",
+              "display": {
+                "kind": "amountNumberDisplayNode",
+                "unit": {
+                  "kind": "stringValueNode",
+                  "string": "base units"
+                }
+              },
               "format": "u64",
               "endian": "le"
             },
@@ -596,9 +671,18 @@
       },
       {
         "kind": "instructionNode",
+        "display": {
+          "kind": "instructionDisplayNode",
+          "intent": "Approve delegate",
+          "interpolatedIntent": "Approve ${accounts.delegate} to spend ${data.amount} from ${accounts.source}"
+        },
         "accounts": [
           {
             "kind": "instructionAccountNode",
+            "display": {
+              "kind": "instructionAccountDisplayNode",
+              "label": "Token Account"
+            },
             "name": "source",
             "isWritable": true,
             "isSigner": false,
@@ -625,6 +709,10 @@
         "arguments": [
           {
             "kind": "instructionArgumentNode",
+            "display": {
+              "kind": "structFieldDisplayNode",
+              "skip": "always"
+            },
             "name": "discriminator",
             "type": {
               "kind": "numberTypeNode",
@@ -640,6 +728,13 @@
             "name": "amount",
             "type": {
               "kind": "numberTypeNode",
+              "display": {
+                "kind": "amountNumberDisplayNode",
+                "unit": {
+                  "kind": "stringValueNode",
+                  "string": "base units"
+                }
+              },
               "format": "u64",
               "endian": "le"
             },
@@ -673,9 +768,18 @@
       },
       {
         "kind": "instructionNode",
+        "display": {
+          "kind": "instructionDisplayNode",
+          "intent": "Revoke delegate",
+          "interpolatedIntent": "Revoke the delegate of ${accounts.source}"
+        },
         "accounts": [
           {
             "kind": "instructionAccountNode",
+            "display": {
+              "kind": "instructionAccountDisplayNode",
+              "label": "Token Account"
+            },
             "name": "source",
             "isWritable": true,
             "isSigner": false,
@@ -694,6 +798,10 @@
         "arguments": [
           {
             "kind": "instructionArgumentNode",
+            "display": {
+              "kind": "structFieldDisplayNode",
+              "skip": "always"
+            },
             "name": "discriminator",
             "type": {
               "kind": "numberTypeNode",
@@ -729,9 +837,18 @@
       },
       {
         "kind": "instructionNode",
+        "display": {
+          "kind": "instructionDisplayNode",
+          "intent": "Set authority",
+          "interpolatedIntent": "Change an authority of ${accounts.owned}"
+        },
         "accounts": [
           {
             "kind": "instructionAccountNode",
+            "display": {
+              "kind": "instructionAccountDisplayNode",
+              "label": "Account"
+            },
             "name": "owned",
             "isWritable": true,
             "isSigner": false,
@@ -752,6 +869,10 @@
         "arguments": [
           {
             "kind": "instructionArgumentNode",
+            "display": {
+              "kind": "structFieldDisplayNode",
+              "skip": "always"
+            },
             "name": "discriminator",
             "type": {
               "kind": "numberTypeNode",
@@ -808,9 +929,29 @@
       },
       {
         "kind": "instructionNode",
+        "display": {
+          "kind": "instructionDisplayNode",
+          "intent": "Mint tokens",
+          "interpolatedIntent": "Mint ${data.amount} ${accounts.mint} to ${accounts.token}"
+        },
+        "provides": [
+          {
+            "kind": "providedNode",
+            "name": "decimals",
+            "node": {
+              "account": "mint",
+              "kind": "accountFieldValueNode",
+              "path": "decimals"
+            }
+          }
+        ],
         "accounts": [
           {
             "kind": "instructionAccountNode",
+            "accountLink": {
+              "kind": "accountLinkNode",
+              "name": "mint"
+            },
             "name": "mint",
             "isWritable": true,
             "isSigner": false,
@@ -819,6 +960,10 @@
           },
           {
             "kind": "instructionAccountNode",
+            "display": {
+              "kind": "instructionAccountDisplayNode",
+              "label": "To"
+            },
             "name": "token",
             "isWritable": true,
             "isSigner": false,
@@ -839,6 +984,10 @@
         "arguments": [
           {
             "kind": "instructionArgumentNode",
+            "display": {
+              "kind": "structFieldDisplayNode",
+              "skip": "always"
+            },
             "name": "discriminator",
             "type": {
               "kind": "numberTypeNode",
@@ -854,6 +1003,13 @@
             "name": "amount",
             "type": {
               "kind": "numberTypeNode",
+              "display": {
+                "decimals": {
+                  "kind": "injectedValueNode",
+                  "key": "decimals"
+                },
+                "kind": "amountNumberDisplayNode"
+              },
               "format": "u64",
               "endian": "le"
             },
@@ -886,9 +1042,29 @@
       },
       {
         "kind": "instructionNode",
+        "display": {
+          "kind": "instructionDisplayNode",
+          "intent": "Burn tokens",
+          "interpolatedIntent": "Burn ${data.amount} ${accounts.mint} from ${accounts.account}"
+        },
+        "provides": [
+          {
+            "kind": "providedNode",
+            "name": "decimals",
+            "node": {
+              "account": "mint",
+              "kind": "accountFieldValueNode",
+              "path": "decimals"
+            }
+          }
+        ],
         "accounts": [
           {
             "kind": "instructionAccountNode",
+            "display": {
+              "kind": "instructionAccountDisplayNode",
+              "label": "Token Account"
+            },
             "name": "account",
             "isWritable": true,
             "isSigner": false,
@@ -897,6 +1073,10 @@
           },
           {
             "kind": "instructionAccountNode",
+            "accountLink": {
+              "kind": "accountLinkNode",
+              "name": "mint"
+            },
             "name": "mint",
             "isWritable": true,
             "isSigner": false,
@@ -918,6 +1098,10 @@
         "arguments": [
           {
             "kind": "instructionArgumentNode",
+            "display": {
+              "kind": "structFieldDisplayNode",
+              "skip": "always"
+            },
             "name": "discriminator",
             "type": {
               "kind": "numberTypeNode",
@@ -933,6 +1117,13 @@
             "name": "amount",
             "type": {
               "kind": "numberTypeNode",
+              "display": {
+                "decimals": {
+                  "kind": "injectedValueNode",
+                  "key": "decimals"
+                },
+                "kind": "amountNumberDisplayNode"
+              },
               "format": "u64",
               "endian": "le"
             },
@@ -966,9 +1157,18 @@
       },
       {
         "kind": "instructionNode",
+        "display": {
+          "kind": "instructionDisplayNode",
+          "intent": "Close token account",
+          "interpolatedIntent": "Close ${accounts.account} and send its balance to ${accounts.destination}"
+        },
         "accounts": [
           {
             "kind": "instructionAccountNode",
+            "display": {
+              "kind": "instructionAccountDisplayNode",
+              "label": "Token Account"
+            },
             "name": "account",
             "isWritable": true,
             "isSigner": false,
@@ -977,6 +1177,10 @@
           },
           {
             "kind": "instructionAccountNode",
+            "display": {
+              "kind": "instructionAccountDisplayNode",
+              "label": "Recipient"
+            },
             "name": "destination",
             "isWritable": true,
             "isSigner": false,
@@ -995,6 +1199,10 @@
         "arguments": [
           {
             "kind": "instructionArgumentNode",
+            "display": {
+              "kind": "structFieldDisplayNode",
+              "skip": "always"
+            },
             "name": "discriminator",
             "type": {
               "kind": "numberTypeNode",
@@ -1033,9 +1241,18 @@
       },
       {
         "kind": "instructionNode",
+        "display": {
+          "kind": "instructionDisplayNode",
+          "intent": "Freeze token account",
+          "interpolatedIntent": "Freeze ${accounts.account}"
+        },
         "accounts": [
           {
             "kind": "instructionAccountNode",
+            "display": {
+              "kind": "instructionAccountDisplayNode",
+              "label": "Token Account"
+            },
             "name": "account",
             "isWritable": true,
             "isSigner": false,
@@ -1062,6 +1279,10 @@
         "arguments": [
           {
             "kind": "instructionArgumentNode",
+            "display": {
+              "kind": "structFieldDisplayNode",
+              "skip": "always"
+            },
             "name": "discriminator",
             "type": {
               "kind": "numberTypeNode",
@@ -1099,9 +1320,18 @@
       },
       {
         "kind": "instructionNode",
+        "display": {
+          "kind": "instructionDisplayNode",
+          "intent": "Thaw token account",
+          "interpolatedIntent": "Thaw ${accounts.account}"
+        },
         "accounts": [
           {
             "kind": "instructionAccountNode",
+            "display": {
+              "kind": "instructionAccountDisplayNode",
+              "label": "Token Account"
+            },
             "name": "account",
             "isWritable": true,
             "isSigner": false,
@@ -1128,6 +1358,10 @@
         "arguments": [
           {
             "kind": "instructionArgumentNode",
+            "display": {
+              "kind": "structFieldDisplayNode",
+              "skip": "always"
+            },
             "name": "discriminator",
             "type": {
               "kind": "numberTypeNode",
@@ -1165,9 +1399,28 @@
       },
       {
         "kind": "instructionNode",
+        "display": {
+          "kind": "instructionDisplayNode",
+          "intent": "Transfer tokens",
+          "interpolatedIntent": "Transfer ${data.amount} ${accounts.mint} from ${accounts.source} to ${accounts.destination}"
+        },
+        "provides": [
+          {
+            "kind": "providedNode",
+            "name": "decimals",
+            "node": {
+              "kind": "argumentValueNode",
+              "name": "decimals"
+            }
+          }
+        ],
         "accounts": [
           {
             "kind": "instructionAccountNode",
+            "display": {
+              "kind": "instructionAccountDisplayNode",
+              "label": "From"
+            },
             "name": "source",
             "isWritable": true,
             "isSigner": false,
@@ -1184,6 +1437,10 @@
           },
           {
             "kind": "instructionAccountNode",
+            "display": {
+              "kind": "instructionAccountDisplayNode",
+              "label": "To"
+            },
             "name": "destination",
             "isWritable": true,
             "isSigner": false,
@@ -1205,6 +1462,10 @@
         "arguments": [
           {
             "kind": "instructionArgumentNode",
+            "display": {
+              "kind": "structFieldDisplayNode",
+              "skip": "always"
+            },
             "name": "discriminator",
             "type": {
               "kind": "numberTypeNode",
@@ -1220,6 +1481,13 @@
             "name": "amount",
             "type": {
               "kind": "numberTypeNode",
+              "display": {
+                "decimals": {
+                  "kind": "injectedValueNode",
+                  "key": "decimals"
+                },
+                "kind": "amountNumberDisplayNode"
+              },
               "format": "u64",
               "endian": "le"
             },
@@ -1227,6 +1495,10 @@
           },
           {
             "kind": "instructionArgumentNode",
+            "display": {
+              "kind": "structFieldDisplayNode",
+              "skip": "whenInjected"
+            },
             "name": "decimals",
             "type": {
               "kind": "numberTypeNode",
@@ -1270,9 +1542,28 @@
       },
       {
         "kind": "instructionNode",
+        "display": {
+          "kind": "instructionDisplayNode",
+          "intent": "Approve delegate",
+          "interpolatedIntent": "Approve ${accounts.delegate} to spend ${data.amount} ${accounts.mint} from ${accounts.source}"
+        },
+        "provides": [
+          {
+            "kind": "providedNode",
+            "name": "decimals",
+            "node": {
+              "kind": "argumentValueNode",
+              "name": "decimals"
+            }
+          }
+        ],
         "accounts": [
           {
             "kind": "instructionAccountNode",
+            "display": {
+              "kind": "instructionAccountDisplayNode",
+              "label": "Token Account"
+            },
             "name": "source",
             "isWritable": true,
             "isSigner": false,
@@ -1307,6 +1598,10 @@
         "arguments": [
           {
             "kind": "instructionArgumentNode",
+            "display": {
+              "kind": "structFieldDisplayNode",
+              "skip": "always"
+            },
             "name": "discriminator",
             "type": {
               "kind": "numberTypeNode",
@@ -1322,6 +1617,13 @@
             "name": "amount",
             "type": {
               "kind": "numberTypeNode",
+              "display": {
+                "decimals": {
+                  "kind": "injectedValueNode",
+                  "key": "decimals"
+                },
+                "kind": "amountNumberDisplayNode"
+              },
               "format": "u64",
               "endian": "le"
             },
@@ -1329,6 +1631,10 @@
           },
           {
             "kind": "instructionArgumentNode",
+            "display": {
+              "kind": "structFieldDisplayNode",
+              "skip": "whenInjected"
+            },
             "name": "decimals",
             "type": {
               "kind": "numberTypeNode",
@@ -1371,6 +1677,21 @@
       },
       {
         "kind": "instructionNode",
+        "display": {
+          "kind": "instructionDisplayNode",
+          "intent": "Mint tokens",
+          "interpolatedIntent": "Mint ${data.amount} ${accounts.mint} to ${accounts.token}"
+        },
+        "provides": [
+          {
+            "kind": "providedNode",
+            "name": "decimals",
+            "node": {
+              "kind": "argumentValueNode",
+              "name": "decimals"
+            }
+          }
+        ],
         "accounts": [
           {
             "kind": "instructionAccountNode",
@@ -1382,6 +1703,10 @@
           },
           {
             "kind": "instructionAccountNode",
+            "display": {
+              "kind": "instructionAccountDisplayNode",
+              "label": "To"
+            },
             "name": "token",
             "isWritable": true,
             "isSigner": false,
@@ -1402,6 +1727,10 @@
         "arguments": [
           {
             "kind": "instructionArgumentNode",
+            "display": {
+              "kind": "structFieldDisplayNode",
+              "skip": "always"
+            },
             "name": "discriminator",
             "type": {
               "kind": "numberTypeNode",
@@ -1417,6 +1746,13 @@
             "name": "amount",
             "type": {
               "kind": "numberTypeNode",
+              "display": {
+                "decimals": {
+                  "kind": "injectedValueNode",
+                  "key": "decimals"
+                },
+                "kind": "amountNumberDisplayNode"
+              },
               "format": "u64",
               "endian": "le"
             },
@@ -1424,6 +1760,10 @@
           },
           {
             "kind": "instructionArgumentNode",
+            "display": {
+              "kind": "structFieldDisplayNode",
+              "skip": "whenInjected"
+            },
             "name": "decimals",
             "type": {
               "kind": "numberTypeNode",
@@ -1465,9 +1805,28 @@
       },
       {
         "kind": "instructionNode",
+        "display": {
+          "kind": "instructionDisplayNode",
+          "intent": "Burn tokens",
+          "interpolatedIntent": "Burn ${data.amount} ${accounts.mint} from ${accounts.account}"
+        },
+        "provides": [
+          {
+            "kind": "providedNode",
+            "name": "decimals",
+            "node": {
+              "kind": "argumentValueNode",
+              "name": "decimals"
+            }
+          }
+        ],
         "accounts": [
           {
             "kind": "instructionAccountNode",
+            "display": {
+              "kind": "instructionAccountDisplayNode",
+              "label": "Token Account"
+            },
             "name": "account",
             "isWritable": true,
             "isSigner": false,
@@ -1497,6 +1856,10 @@
         "arguments": [
           {
             "kind": "instructionArgumentNode",
+            "display": {
+              "kind": "structFieldDisplayNode",
+              "skip": "always"
+            },
             "name": "discriminator",
             "type": {
               "kind": "numberTypeNode",
@@ -1512,6 +1875,13 @@
             "name": "amount",
             "type": {
               "kind": "numberTypeNode",
+              "display": {
+                "decimals": {
+                  "kind": "injectedValueNode",
+                  "key": "decimals"
+                },
+                "kind": "amountNumberDisplayNode"
+              },
               "format": "u64",
               "endian": "le"
             },
@@ -1519,6 +1889,10 @@
           },
           {
             "kind": "instructionArgumentNode",
+            "display": {
+              "kind": "structFieldDisplayNode",
+              "skip": "whenInjected"
+            },
             "name": "decimals",
             "type": {
               "kind": "numberTypeNode",
@@ -1561,9 +1935,18 @@
       },
       {
         "kind": "instructionNode",
+        "display": {
+          "kind": "instructionDisplayNode",
+          "intent": "Initialize token account",
+          "interpolatedIntent": "Initialize token account ${accounts.account} for mint ${accounts.mint}"
+        },
         "accounts": [
           {
             "kind": "instructionAccountNode",
+            "display": {
+              "kind": "instructionAccountDisplayNode",
+              "label": "Token Account"
+            },
             "name": "account",
             "isWritable": true,
             "isSigner": false,
@@ -1580,6 +1963,10 @@
           },
           {
             "kind": "instructionAccountNode",
+            "display": {
+              "kind": "instructionAccountDisplayNode",
+              "skip": "always"
+            },
             "name": "rent",
             "isWritable": false,
             "isSigner": false,
@@ -1594,6 +1981,10 @@
         "arguments": [
           {
             "kind": "instructionArgumentNode",
+            "display": {
+              "kind": "structFieldDisplayNode",
+              "skip": "always"
+            },
             "name": "discriminator",
             "type": {
               "kind": "numberTypeNode",
@@ -1629,9 +2020,18 @@
       },
       {
         "kind": "instructionNode",
+        "display": {
+          "kind": "instructionDisplayNode",
+          "intent": "Sync wrapped SOL",
+          "interpolatedIntent": "Sync the wrapped SOL balance of ${accounts.account}"
+        },
         "accounts": [
           {
             "kind": "instructionAccountNode",
+            "display": {
+              "kind": "instructionAccountDisplayNode",
+              "label": "Token Account"
+            },
             "name": "account",
             "isWritable": true,
             "isSigner": false,
@@ -1642,6 +2042,10 @@
           },
           {
             "kind": "instructionAccountNode",
+            "display": {
+              "kind": "instructionAccountDisplayNode",
+              "skip": "always"
+            },
             "name": "rent",
             "isWritable": false,
             "isSigner": false,
@@ -1656,6 +2060,10 @@
         "arguments": [
           {
             "kind": "instructionArgumentNode",
+            "display": {
+              "kind": "structFieldDisplayNode",
+              "skip": "always"
+            },
             "name": "discriminator",
             "type": {
               "kind": "numberTypeNode",
@@ -1686,9 +2094,18 @@
       },
       {
         "kind": "instructionNode",
+        "display": {
+          "kind": "instructionDisplayNode",
+          "intent": "Initialize token account",
+          "interpolatedIntent": "Initialize token account ${accounts.account} for mint ${accounts.mint}"
+        },
         "accounts": [
           {
             "kind": "instructionAccountNode",
+            "display": {
+              "kind": "instructionAccountDisplayNode",
+              "label": "Token Account"
+            },
             "name": "account",
             "isWritable": true,
             "isSigner": false,
@@ -1707,6 +2124,10 @@
         "arguments": [
           {
             "kind": "instructionArgumentNode",
+            "display": {
+              "kind": "structFieldDisplayNode",
+              "skip": "always"
+            },
             "name": "discriminator",
             "type": {
               "kind": "numberTypeNode",
@@ -1739,6 +2160,11 @@
       },
       {
         "kind": "instructionNode",
+        "display": {
+          "kind": "instructionDisplayNode",
+          "intent": "Initialize multisig",
+          "interpolatedIntent": "Initialize multisig ${accounts.multisig} requiring ${data.m} signatures"
+        },
         "accounts": [
           {
             "kind": "instructionAccountNode",
@@ -1752,6 +2178,10 @@
         "arguments": [
           {
             "kind": "instructionArgumentNode",
+            "display": {
+              "kind": "structFieldDisplayNode",
+              "skip": "always"
+            },
             "name": "discriminator",
             "type": {
               "kind": "numberTypeNode",
@@ -1764,6 +2194,10 @@
           },
           {
             "kind": "instructionArgumentNode",
+            "display": {
+              "kind": "structFieldDisplayNode",
+              "label": "Required Signatures"
+            },
             "name": "m",
             "type": {
               "kind": "numberTypeNode",
@@ -1785,6 +2219,10 @@
         "remainingAccounts": [
           {
             "kind": "instructionRemainingAccountsNode",
+            "display": {
+              "kind": "instructionAccountDisplayNode",
+              "label": "Signers"
+            },
             "value": {
               "kind": "argumentValueNode",
               "name": "signers"
@@ -1799,6 +2237,11 @@
       },
       {
         "kind": "instructionNode",
+        "display": {
+          "kind": "instructionDisplayNode",
+          "intent": "Initialize mint",
+          "interpolatedIntent": "Initialize mint ${accounts.mint} with ${data.decimals} decimals"
+        },
         "accounts": [
           {
             "kind": "instructionAccountNode",
@@ -1812,6 +2255,10 @@
         "arguments": [
           {
             "kind": "instructionArgumentNode",
+            "display": {
+              "kind": "structFieldDisplayNode",
+              "skip": "always"
+            },
             "name": "discriminator",
             "type": {
               "kind": "numberTypeNode",
@@ -1876,6 +2323,11 @@
       },
       {
         "kind": "instructionNode",
+        "display": {
+          "kind": "instructionDisplayNode",
+          "intent": "Get account data size",
+          "interpolatedIntent": "Get the account size for mint ${accounts.mint}"
+        },
         "accounts": [
           {
             "kind": "instructionAccountNode",
@@ -1889,6 +2341,10 @@
         "arguments": [
           {
             "kind": "instructionArgumentNode",
+            "display": {
+              "kind": "structFieldDisplayNode",
+              "skip": "always"
+            },
             "name": "discriminator",
             "type": {
               "kind": "numberTypeNode",
@@ -1919,9 +2375,18 @@
       },
       {
         "kind": "instructionNode",
+        "display": {
+          "kind": "instructionDisplayNode",
+          "intent": "Initialize immutable owner",
+          "interpolatedIntent": "Make the owner of ${accounts.account} immutable"
+        },
         "accounts": [
           {
             "kind": "instructionAccountNode",
+            "display": {
+              "kind": "instructionAccountDisplayNode",
+              "label": "Token Account"
+            },
             "name": "account",
             "isWritable": true,
             "isSigner": false,
@@ -1932,6 +2397,10 @@
         "arguments": [
           {
             "kind": "instructionArgumentNode",
+            "display": {
+              "kind": "structFieldDisplayNode",
+              "skip": "always"
+            },
             "name": "discriminator",
             "type": {
               "kind": "numberTypeNode",
@@ -1964,6 +2433,10 @@
       },
       {
         "kind": "instructionNode",
+        "display": {
+          "kind": "instructionDisplayNode",
+          "intent": "Convert amount to UI amount"
+        },
         "accounts": [
           {
             "kind": "instructionAccountNode",
@@ -1977,6 +2450,10 @@
         "arguments": [
           {
             "kind": "instructionArgumentNode",
+            "display": {
+              "kind": "structFieldDisplayNode",
+              "skip": "always"
+            },
             "name": "discriminator",
             "type": {
               "kind": "numberTypeNode",
@@ -1992,6 +2469,13 @@
             "name": "amount",
             "type": {
               "kind": "numberTypeNode",
+              "display": {
+                "kind": "amountNumberDisplayNode",
+                "unit": {
+                  "kind": "stringValueNode",
+                  "string": "base units"
+                }
+              },
               "format": "u64",
               "endian": "le"
             },
@@ -2020,6 +2504,10 @@
       },
       {
         "kind": "instructionNode",
+        "display": {
+          "kind": "instructionDisplayNode",
+          "intent": "Convert UI amount to amount"
+        },
         "accounts": [
           {
             "kind": "instructionAccountNode",
@@ -2033,6 +2521,10 @@
         "arguments": [
           {
             "kind": "instructionArgumentNode",
+            "display": {
+              "kind": "structFieldDisplayNode",
+              "skip": "always"
+            },
             "name": "discriminator",
             "type": {
               "kind": "numberTypeNode",
@@ -2045,6 +2537,10 @@
           },
           {
             "kind": "instructionArgumentNode",
+            "display": {
+              "kind": "structFieldDisplayNode",
+              "label": "UI Amount"
+            },
             "name": "uiAmount",
             "type": {
               "kind": "stringTypeNode",
@@ -2073,9 +2569,18 @@
       },
       {
         "kind": "instructionNode",
+        "display": {
+          "kind": "instructionDisplayNode",
+          "intent": "Withdraw excess SOL",
+          "interpolatedIntent": "Withdraw excess SOL from ${accounts.source} to ${accounts.destination}"
+        },
         "accounts": [
           {
             "kind": "instructionAccountNode",
+            "display": {
+              "kind": "instructionAccountDisplayNode",
+              "label": "From"
+            },
             "name": "source",
             "isWritable": true,
             "isSigner": false,
@@ -2084,6 +2589,10 @@
           },
           {
             "kind": "instructionAccountNode",
+            "display": {
+              "kind": "instructionAccountDisplayNode",
+              "label": "To"
+            },
             "name": "destination",
             "isWritable": true,
             "isSigner": false,
@@ -2102,6 +2611,10 @@
         "arguments": [
           {
             "kind": "instructionArgumentNode",
+            "display": {
+              "kind": "structFieldDisplayNode",
+              "skip": "always"
+            },
             "name": "discriminator",
             "type": {
               "kind": "numberTypeNode",
@@ -2141,9 +2654,18 @@
       },
       {
         "kind": "instructionNode",
+        "display": {
+          "kind": "instructionDisplayNode",
+          "intent": "Unwrap SOL",
+          "interpolatedIntent": "Unwrap SOL from ${accounts.source} to ${accounts.destination}"
+        },
         "accounts": [
           {
             "kind": "instructionAccountNode",
+            "display": {
+              "kind": "instructionAccountDisplayNode",
+              "label": "From"
+            },
             "name": "source",
             "isWritable": true,
             "isSigner": false,
@@ -2152,6 +2674,10 @@
           },
           {
             "kind": "instructionAccountNode",
+            "display": {
+              "kind": "instructionAccountDisplayNode",
+              "label": "To"
+            },
             "name": "destination",
             "isWritable": true,
             "isSigner": false,
@@ -2170,6 +2696,10 @@
         "arguments": [
           {
             "kind": "instructionArgumentNode",
+            "display": {
+              "kind": "structFieldDisplayNode",
+              "skip": "always"
+            },
             "name": "discriminator",
             "type": {
               "kind": "numberTypeNode",
@@ -2187,6 +2717,17 @@
               "kind": "optionTypeNode",
               "item": {
                 "kind": "numberTypeNode",
+                "display": {
+                  "decimals": {
+                    "kind": "numberValueNode",
+                    "number": 9
+                  },
+                  "kind": "amountNumberDisplayNode",
+                  "unit": {
+                    "kind": "stringValueNode",
+                    "string": "SOL"
+                  }
+                },
                 "format": "u64",
                 "endian": "le"
               },
@@ -2232,10 +2773,18 @@
       },
       {
         "kind": "instructionNode",
+        "display": {
+          "kind": "instructionDisplayNode",
+          "intent": "Batch instructions"
+        },
         "accounts": [],
         "arguments": [
           {
             "kind": "instructionArgumentNode",
+            "display": {
+              "kind": "structFieldDisplayNode",
+              "skip": "always"
+            },
             "name": "discriminator",
             "type": {
               "kind": "numberTypeNode",
@@ -2248,6 +2797,10 @@
           },
           {
             "kind": "instructionArgumentNode",
+            "display": {
+              "kind": "structFieldDisplayNode",
+              "label": "Batched Instructions"
+            },
             "name": "data",
             "type": {
               "kind": "arrayTypeNode",
@@ -2530,6 +3083,11 @@
       "instructions": [
         {
           "kind": "instructionNode",
+          "display": {
+            "kind": "instructionDisplayNode",
+            "intent": "Create associated token account",
+            "interpolatedIntent": "Create associated token account ${accounts.ata} for ${accounts.owner}"
+          },
           "accounts": [
             {
               "kind": "instructionAccountNode",
@@ -2542,6 +3100,10 @@
             },
             {
               "kind": "instructionAccountNode",
+              "display": {
+                "kind": "instructionAccountDisplayNode",
+                "label": "Token Account"
+              },
               "name": "ata",
               "isWritable": true,
               "isSigner": false,
@@ -2599,6 +3161,10 @@
             },
             {
               "kind": "instructionAccountNode",
+              "display": {
+                "kind": "instructionAccountDisplayNode",
+                "skip": "always"
+              },
               "name": "systemProgram",
               "isWritable": false,
               "isSigner": false,
@@ -2625,6 +3191,10 @@
           "arguments": [
             {
               "kind": "instructionArgumentNode",
+              "display": {
+                "kind": "structFieldDisplayNode",
+                "skip": "always"
+              },
               "name": "discriminator",
               "type": {
                 "kind": "numberTypeNode",
@@ -2652,6 +3222,11 @@
         },
         {
           "kind": "instructionNode",
+          "display": {
+            "kind": "instructionDisplayNode",
+            "intent": "Create associated token account",
+            "interpolatedIntent": "Create associated token account ${accounts.ata} for ${accounts.owner}"
+          },
           "accounts": [
             {
               "kind": "instructionAccountNode",
@@ -2664,6 +3239,10 @@
             },
             {
               "kind": "instructionAccountNode",
+              "display": {
+                "kind": "instructionAccountDisplayNode",
+                "label": "Token Account"
+              },
               "name": "ata",
               "isWritable": true,
               "isSigner": false,
@@ -2721,6 +3300,10 @@
             },
             {
               "kind": "instructionAccountNode",
+              "display": {
+                "kind": "instructionAccountDisplayNode",
+                "skip": "always"
+              },
               "name": "systemProgram",
               "isWritable": false,
               "isSigner": false,
@@ -2747,6 +3330,10 @@
           "arguments": [
             {
               "kind": "instructionArgumentNode",
+              "display": {
+                "kind": "structFieldDisplayNode",
+                "skip": "always"
+              },
               "name": "discriminator",
               "type": {
                 "kind": "numberTypeNode",
@@ -2775,9 +3362,18 @@
         },
         {
           "kind": "instructionNode",
+          "display": {
+            "kind": "instructionDisplayNode",
+            "intent": "Recover nested token account",
+            "interpolatedIntent": "Recover nested token account ${accounts.nestedAssociatedAccountAddress} to ${accounts.destinationAssociatedAccountAddress}"
+          },
           "accounts": [
             {
               "kind": "instructionAccountNode",
+              "display": {
+                "kind": "instructionAccountDisplayNode",
+                "label": "Nested Token Account"
+              },
               "name": "nestedAssociatedAccountAddress",
               "isWritable": true,
               "isSigner": false,
@@ -2821,6 +3417,10 @@
             },
             {
               "kind": "instructionAccountNode",
+              "display": {
+                "kind": "instructionAccountDisplayNode",
+                "label": "Nested Mint"
+              },
               "name": "nestedTokenMintAddress",
               "isWritable": false,
               "isSigner": false,
@@ -2829,6 +3429,10 @@
             },
             {
               "kind": "instructionAccountNode",
+              "display": {
+                "kind": "instructionAccountDisplayNode",
+                "label": "Destination Token Account"
+              },
               "name": "destinationAssociatedAccountAddress",
               "isWritable": true,
               "isSigner": false,
@@ -2870,6 +3474,10 @@
             },
             {
               "kind": "instructionAccountNode",
+              "display": {
+                "kind": "instructionAccountDisplayNode",
+                "label": "Owner Token Account"
+              },
               "name": "ownerAssociatedAccountAddress",
               "isWritable": false,
               "isSigner": false,
@@ -2913,6 +3521,10 @@
             },
             {
               "kind": "instructionAccountNode",
+              "display": {
+                "kind": "instructionAccountDisplayNode",
+                "label": "Owner Mint"
+              },
               "name": "ownerTokenMintAddress",
               "isWritable": false,
               "isSigner": false,
@@ -2921,6 +3533,10 @@
             },
             {
               "kind": "instructionAccountNode",
+              "display": {
+                "kind": "instructionAccountDisplayNode",
+                "label": "Wallet"
+              },
               "name": "walletAddress",
               "isWritable": true,
               "isSigner": true,
@@ -2943,6 +3559,10 @@
           "arguments": [
             {
               "kind": "instructionArgumentNode",
+              "display": {
+                "kind": "structFieldDisplayNode",
+                "skip": "always"
+              },
               "name": "discriminator",
               "type": {
                 "kind": "numberTypeNode",

--- a/idl.json
+++ b/idl.json
@@ -3086,7 +3086,7 @@
           "display": {
             "kind": "instructionDisplayNode",
             "intent": "Create associated token account",
-            "interpolatedIntent": "Create associated token account ${accounts.ata} for ${accounts.owner}"
+            "interpolatedIntent": "Create the associated token account of ${accounts.owner} for mint ${accounts.mint}"
           },
           "accounts": [
             {
@@ -3225,7 +3225,7 @@
           "display": {
             "kind": "instructionDisplayNode",
             "intent": "Create associated token account",
-            "interpolatedIntent": "Create associated token account ${accounts.ata} for ${accounts.owner}"
+            "interpolatedIntent": "Create the associated token account of ${accounts.owner} for mint ${accounts.mint}"
           },
           "accounts": [
             {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "private": true,
     "devDependencies": {
         "@codama/renderers-js": "^2.3.0",
-        "codama": "^1.8.0"
+        "codama": "^1.10.0"
     },
     "engines": {
         "node": ">=v20.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,13 +12,17 @@ importers:
         specifier: ^2.3.0
         version: 2.3.0
       codama:
-        specifier: ^1.8.0
-        version: 1.8.0
+        specifier: ^1.10.0
+        version: 1.10.0
 
 packages:
 
-  '@codama/cli@1.5.3':
-    resolution: {integrity: sha512-RgLwZ24sGkPDwaH3DovOY3e1VXPnPwDBXojYXyOzPmEjQ23yTKacrLa3Zlt/XjMsXv9cLOym5OheC+gG6GxIpg==}
+  '@codama/cli@1.6.0':
+    resolution: {integrity: sha512-68fam0kzWsKp2ip/LZn3kDyFjWcbzHExCuDgEHGTX8C0gSscMch/c4EgtTq7NsWKc1cse0GMC5WIxCFumroTyQ==}
+    hasBin: true
+
+  '@codama/errors@1.10.0':
+    resolution: {integrity: sha512-/qiWQcbPIsyFlP1LrLqJfHt1QNbkY2wtC4UxZyKLnuZtc62YPlgDrN2wp4wcfRuE/DC0n3Y6ZSwYUrDBZyAnvA==}
     hasBin: true
 
   '@codama/errors@1.8.0':
@@ -28,8 +32,14 @@ packages:
   '@codama/fragments@0.1.1':
     resolution: {integrity: sha512-+DeC2YklyYf+qjRkoTKeG6HFgwsW7hiQko7er18dgsxF15M316EwYL2W40nKDPWlEhB/iME+sZR5++VQPUO/6w==}
 
+  '@codama/node-types@1.10.0':
+    resolution: {integrity: sha512-fMoJQ8TgB9A5Pl+GA8ffhDbGK63cV1nrbDrYTgIhPDKeVqBSdkSAoAuAtvWfRd7X2ML73H6RRi6jZRJmo2xfHQ==}
+
   '@codama/node-types@1.8.0':
     resolution: {integrity: sha512-KE9K9jjEdeFKtDKRrjjm5YwEkg7l+YwoWiH2w1UXJL/x6P5uul6+O5WnGsJn8IFtBVSLN4hbD7YSsZ0/lktJxQ==}
+
+  '@codama/nodes@1.10.0':
+    resolution: {integrity: sha512-P3NXVw6kZq2VDb4wYU6zQ3xFksDqSuDYqp11P6Dpei9XIZZ11NtL2jBjBcqsIudGIx104bMgSo4SZ7Hlej056A==}
 
   '@codama/nodes@1.8.0':
     resolution: {integrity: sha512-rl+7BxYatAE6uq5h9b5fEilGLd3YeJaJxqgLDAvdKQ5pspq6ch5ww9NiigkwdvDYli1Yk56PRhMZdLsiZIVgAA==}
@@ -41,14 +51,17 @@ packages:
     resolution: {integrity: sha512-PSvoLATBx7EomzZgCXegPTn5TxaFjA+NIraNUx22vNZ6rxPxu5Tctq8KxeXaaPCnKLpBUKcwmhUPRO4QLNQlvg==}
     engines: {node: '>=20.18.0'}
 
-  '@codama/validators@1.8.0':
-    resolution: {integrity: sha512-gDmS85DwWmT41+PWTlbBrkSopGKW4UPhEcX+SLb2fF/uXMpJQXcgLE8BE9Fr7/DO+M9yFtGOVrnfDSCwepORGg==}
+  '@codama/validators@1.10.0':
+    resolution: {integrity: sha512-5WH1IHmyVVG/9QThZsrVM2ROv5w3yLF/8+4HK/kr8uw0ZXnIBGidnmyrxr1P8V+X6DgZqKJaX46V30dSs/NOTQ==}
+
+  '@codama/visitors-core@1.10.0':
+    resolution: {integrity: sha512-8koBGs4m/NI4nDLJZx7Q1KzRUKkBy/GAnZq4xOEFGlhTvDCIAzEgo3biAhNFynGY45gzZJSX08QTDWKsPRjnaA==}
 
   '@codama/visitors-core@1.8.0':
     resolution: {integrity: sha512-CLO0icVvzAutjI7imuN1Rib0/GIBc7hhwQ5gcE3aVAVBHUNS4M27BzagqYTpL0cMC9I1tL9c6lhpCBV2kKs6Zg==}
 
-  '@codama/visitors@1.8.0':
-    resolution: {integrity: sha512-vQ863YkHBdLWZeaiPKisiRe0bbuBEBe9xDWVcLCCLRsmKCQuS+GB4bKxIwrlTr9cxCOGyQLkI7B/yAqyYEdbmw==}
+  '@codama/visitors@1.10.0':
+    resolution: {integrity: sha512-xAGKosZQnXBo9MiHFipA9Dsec1k9nbpv5UgUyY1j3l85FGEZQT2tHqrNxtBmPrC3LNSLVOfAdiUUMVUXUX5ydA==}
 
   '@solana/codecs-core@6.9.0':
     resolution: {integrity: sha512-F2BmLecG/1nTtnjyD509NsEc254pxJKa2bpvotymv1lL1WfEn3zchcZ9SMIiLyL4G6J8b9F3OKIq2YSZho2AOQ==}
@@ -106,8 +119,8 @@ packages:
     resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
 
-  codama@1.8.0:
-    resolution: {integrity: sha512-P1hctEUpZfgjm3xfosrD4xo/SVnp17ONuGDDtBmkyOaJBBL2JkYXjomZF9xOQqhvlfgcgqRKNB96Lcs4MG/fLQ==}
+  codama@1.10.0:
+    resolution: {integrity: sha512-fH1wz1P6bbPOWNM23Sk4VzRSpqxRW1CpXNiWQY23vHT2tno/K1/JtaaUc7DS5ddl5rGFKtq9R2UFsegR96IxRQ==}
     hasBin: true
 
   commander@14.0.3:
@@ -208,14 +221,20 @@ packages:
 
 snapshots:
 
-  '@codama/cli@1.5.3':
+  '@codama/cli@1.6.0':
     dependencies:
-      '@codama/nodes': 1.8.0
-      '@codama/visitors': 1.8.0
-      '@codama/visitors-core': 1.8.0
+      '@codama/nodes': 1.10.0
+      '@codama/visitors': 1.10.0
+      '@codama/visitors-core': 1.10.0
       commander: 14.0.3
       picocolors: 1.1.1
       prompts: 2.4.2
+
+  '@codama/errors@1.10.0':
+    dependencies:
+      '@codama/node-types': 1.10.0
+      commander: 14.0.3
+      picocolors: 1.1.1
 
   '@codama/errors@1.8.0':
     dependencies:
@@ -227,7 +246,14 @@ snapshots:
     dependencies:
       '@codama/errors': 1.8.0
 
+  '@codama/node-types@1.10.0': {}
+
   '@codama/node-types@1.8.0': {}
+
+  '@codama/nodes@1.10.0':
+    dependencies:
+      '@codama/errors': 1.10.0
+      '@codama/node-types': 1.10.0
 
   '@codama/nodes@1.8.0':
     dependencies:
@@ -254,11 +280,17 @@ snapshots:
       - fastestsmallesttextencoderdecoder
       - typescript
 
-  '@codama/validators@1.8.0':
+  '@codama/validators@1.10.0':
     dependencies:
-      '@codama/errors': 1.8.0
-      '@codama/nodes': 1.8.0
-      '@codama/visitors-core': 1.8.0
+      '@codama/errors': 1.10.0
+      '@codama/nodes': 1.10.0
+      '@codama/visitors-core': 1.10.0
+
+  '@codama/visitors-core@1.10.0':
+    dependencies:
+      '@codama/errors': 1.10.0
+      '@codama/nodes': 1.10.0
+      json-stable-stringify: 1.3.0
 
   '@codama/visitors-core@1.8.0':
     dependencies:
@@ -266,11 +298,11 @@ snapshots:
       '@codama/nodes': 1.8.0
       json-stable-stringify: 1.3.0
 
-  '@codama/visitors@1.8.0':
+  '@codama/visitors@1.10.0':
     dependencies:
-      '@codama/errors': 1.8.0
-      '@codama/nodes': 1.8.0
-      '@codama/visitors-core': 1.8.0
+      '@codama/errors': 1.10.0
+      '@codama/nodes': 1.10.0
+      '@codama/visitors-core': 1.10.0
 
   '@solana/codecs-core@6.9.0':
     dependencies:
@@ -311,13 +343,13 @@ snapshots:
 
   chalk@5.6.2: {}
 
-  codama@1.8.0:
+  codama@1.10.0:
     dependencies:
-      '@codama/cli': 1.5.3
-      '@codama/errors': 1.8.0
-      '@codama/nodes': 1.8.0
-      '@codama/validators': 1.8.0
-      '@codama/visitors': 1.8.0
+      '@codama/cli': 1.6.0
+      '@codama/errors': 1.10.0
+      '@codama/nodes': 1.10.0
+      '@codama/validators': 1.10.0
+      '@codama/visitors': 1.10.0
 
   commander@14.0.3: {}
 


### PR DESCRIPTION
This PR enriches the Codama IDL with display metadata for clear signing, per [sRFC 39](https://github.com/solana-foundation/SRFCs/discussions/4), and bumps `codama` to `^1.10.0` (the display node types shipped in 1.9). All 28 token instructions and the 3 associated-token-account instructions gain intents, interpolated intents and labels.

Token amounts scale through the provide/inject graph:

- Checked variants provide `decimals` from their own `decimals` argument — fully offline, ideal for hardware wallets; the redundant argument is hidden once consumed (`skip: "whenInjected"`).
- `mintTo`/`burn` provide `decimals` from the mint account (`accountFieldValueNode` + `accountLink`), degrading gracefully to raw without account access.
- Amounts with no mint in reach (`transfer`, `approve`) render explicitly as `base units`.

Sample renders via `@codama/dynamic-instructions` (the mint address resolves to a symbol when the renderer names it):

```
Transfer 1.5 EPjFW… from CiDwV… to DRpbC…
Mint 1.5 EPjFW… to HN7cA…
Transfer 1500000 base units from CiDwV… to DRpbC…
Close 4Nd1m… and send its balance to 9WzDX…
```

Clients were regenerated and are unaffected: renderers pass display metadata through untouched.